### PR TITLE
Zuul: don't specify 'project.name'

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    name: packit-service/deployment
     check:
       jobs:
         - pre-commit


### PR DESCRIPTION
When zuul configuration is stored in the repository, 'project.name' is
guessed from the repo name, so there is no need to specify it.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>