### PR TITLE
Create base image Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,8 @@ generate-local-secrets:
 
 deploy-validation:
 	$(AP) cron-jobs/validation/deploy-validation.yaml
+
+# DEPLOYMENT is always stg because this cronjob is not related to specific deployment stage a
+# needs be configure only once
+deploy-rebuild-base-image:
+	DEPLOYMENT=stg $(AP) playbooks/rebuild-base-image.yml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - [Openshift](openshift/) - Openshift resource configuration files (templates).
 - [secrets](secrets/) - secret stuff to be used from `openshift/secret-*.yml.j2`
 - [scripts](scripts/) - devops scripts used in multiple repositories
+- [cron-jobs](cron-jobs/) - OpenShift cron jobs
+- [containers](containers/) - files used to build container images
 
 ### Images
 
@@ -40,6 +42,8 @@ Image builds are triggered by new commits on Docker Hub. ([Autobuild docs](https
 
 In packit-service we use a custom build hook to be able to inject ENV variables
 provided by the build process. ([docs](https://docs.docker.com/docker-hub/builds/advanced/))
+
+From more details about local builds pls check [link](https://github.com/packit/packit-service/blob/master/CONTRIBUTING.md#building-images-locally)
 
 ### Continuous Deployment
 

--- a/containers/Dockerfile.base
+++ b/containers/Dockerfile.base
@@ -1,3 +1,6 @@
+# Be aware that this image is used for all stages, so if a dependency is removed be sure that it is
+# not required in anywhere
+
 FROM fedora:31
 
 ENV LANG=en_US.UTF-8 \

--- a/cron-jobs/README.md
+++ b/cron-jobs/README.md
@@ -1,0 +1,17 @@
+# Opneshift cron jobs
+
+Currently cron jobs configuration is not fully consistent, there is issue opened for it (#112).
+
+## rebuild-base-image
+
+The `rebuild-base-image` CronJob is rebuilding the base image using a DockerHub webhook. The webhook is stored in the secrets repo.
+
+Rebuild-base-image is deployed using root Makefile:
+
+```shell script
+DEPLOYMENT=stg make deploy-rebuild-base-image
+```
+
+Note:
+This cron job is not related to specific deployment stage and because there is no dedicated
+namespace in OpenShift for this purpose, it is deployed to packit-stg namespace.

--- a/cron-jobs/rebuild-base-image/rebuild-base-image.yaml
+++ b/cron-jobs/rebuild-base-image/rebuild-base-image.yaml
@@ -1,0 +1,30 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: rebuild-base-image
+spec:
+  # runs every day at 3 a.m.
+  schedule: "0 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: rebuild-base-image
+              image: fedora
+              env:
+                - name: BASE_BUILD_WEBHOOK
+                  valueFrom:
+                    secretKeyRef:
+                      name: rebuild-base-image
+                      key: base_build_webhook
+              command:
+                ["/bin/bash", "-c", "/usr/bin/curl -X POST $BASE_BUILD_WEBHOOK"]
+              resources:
+                limits:
+                  memory: "80Mi"
+                  cpu: "100m"
+          restartPolicy: OnFailure

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,7 @@
+FROM fedora:31
+
+ENV LANG=en_US.UTF-8 \
+    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
+    ANSIBLE_STDOUT_CALLBACK=debug
+
+RUN dnf install -y ansible && dnf clean all

--- a/openshift/secret-rebuild-base-image.yml.j2
+++ b/openshift/secret-rebuild-base-image.yml.j2
@@ -1,0 +1,11 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rebuild-base-image
+type: Opaque
+data:
+  base_build_webhook: "{{ base_build_webhook | b64encode }}"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -56,6 +56,11 @@
       tags:
         - always
 
+    - name: secrets not related specific deployment stage
+      include_vars: "{{ path_to_secrets }}/secrets.yaml"
+      tags:
+        - always
+
     - name: Get k8s token and check it.
       block:
         - name: get kubeconfig token
@@ -97,6 +102,7 @@
         - "{{ lookup('template', '../openshift/secret-packit-config.yml.j2') }}"
         - "{{ lookup('template', '../openshift/secret-sentry.yml.j2') }}"
         - "{{ lookup('template', '../openshift/secret-postgres.yml.j2') }}"
+        - "{{ lookup('template', '../openshift/secret-rebuild-base-image.yml.j2') }}"
         - "{{ lookup('template', '../openshift/sandbox-namespace.yml.j2') }}"
       tags:
         - always

--- a/playbooks/rebuild-base-image.yml
+++ b/playbooks/rebuild-base-image.yml
@@ -1,0 +1,18 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+- name: Rebuild base image
+  hosts: all
+  vars:
+    deployment: "{{ lookup('env', 'DEPLOYMENT') }}"
+  tasks:
+    - name: include variables
+      include_vars: ../vars/{{ deployment }}.yml
+
+    - name: oc login
+      command: oc login {{ host }} --token={{ api_key }} --insecure-skip-tls-verify
+      # it doesn't change anything, so don't report 'changed'
+      changed_when: false
+
+    - name: deploy rebuild-base-image cronjob
+      command: oc apply -f ../cron-jobs/rebuild-base-image/rebuild-base-image.yaml


### PR DESCRIPTION
Base image build based on this configuration will contain the most generic
dependencies - only ansible rpm for now.

This PR contains:
* base Dockerfile
* OpenShift cronjob configuration
* secret with DockerHub webhook to trigger a build
* Makefile target to deploy it into OpenShift
* Documentation (+ small improvements to unrelated parts)