### PR TITLE
Workers now request 2Gi (was 1Gi) storage

### DIFF
--- a/openshift/packit-service-worker.yml.j2
+++ b/openshift/packit-service-worker.yml.j2
@@ -46,7 +46,7 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 1Gi
+            storage: 2Gi
   updateStrategy.type: RollingUpdate
   podManagementPolicy: OrderedReady
   template:


### PR DESCRIPTION
To work-around source-git/kernel SRPM builds failing on
No space left on device

We now have 34Gi storage quota in total so
4(workers)*1Gi more shouldn't be a problem.