### PR TITLE
Change storage in volume for tokman to 1Gi

### DIFF
--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -134,4 +134,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 256Mi
+      storage: 1Gi


### PR DESCRIPTION
I was trying to deploy tokman on stg and got error message with this configuration (`forbidden: minimum storage usage per PersistentVolumeClaim is 1Gi, but request is 256Mi`), so changed it to 1Gi