### PR TITLE
Add env vars to be able to run Sentry in tokman, p-s

### DIFF
--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -68,6 +68,11 @@ spec:
                 secretKeyRef:
                   key: database-name
                   name: postgres-secret
+            - name: SENTRY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: packit-sentry
+                  key: sentry
           volumeMounts:
             - name: packit-secrets
               mountPath: /secrets

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -30,6 +30,8 @@ spec:
         - name: tokman
           image: tokman:{{ deployment }}
           env:
+            - name: DEPLOYMENT
+              value: {{ deployment }}
             - name: LOG_LEVEL
               value: DEBUG
             - name: WORKERS
@@ -38,6 +40,11 @@ spec:
               value: /etc/config/config.py
             - name: BIND_ADDR
               value: "0.0.0.0:8000"
+            - name: SENTRY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: packit-sentry
+                  key: sentry
           volumeMounts:
             - name: github-app-private-key
               mountPath: /secrets


### PR DESCRIPTION
- add `SENTRY_SECRET`, `DEPLOYMENT` vars to tokman env
- add `SENTRY_SECRET` var to packit-service env (packit/packit-service#784 - I see `configure_sentry()` is called also in service, but the env var is not set)