### PR TITLE
Control pushing dev images with a dedicated flag

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -34,6 +34,7 @@
     with_flower: true
     with_dashboard: true
     with_beat: true
+    push_dev_images: false
     image: "docker.io/usercont/packit-service:{{ deployment }}"
     image_worker: "docker.io/usercont/packit-service-worker:{{ deployment }}"
     image_fedmsg: "docker.io/usercont/packit-service-fedmsg:{{ deployment }}"
@@ -97,7 +98,7 @@
         - command: "{{ container_engine }} inspect {{ image_worker }}"
         - command: "{{ container_engine }} tag {{ image_worker }} 172.30.1.1:5000/myproject/packit-worker:dev"
         - command: "{{ container_engine }} push 172.30.1.1:5000/myproject/packit-worker:dev {{ tls_verify_false }}"
-      when: deployment == "dev"
+      when: push_dev_images
       tags:
         - packit-service
         - packit-service-worker

--- a/vars/dev_template.yml
+++ b/vars/dev_template.yml
@@ -81,3 +81,5 @@ with_beat: false
 # It's set to "/usr/bin/podman" if there's podman installed, or to 'docker' otherwise.
 # If you still want to use docker even when podman is installed, set:
 # container_engine: "docker"
+
+push_dev_images: true


### PR DESCRIPTION
Up until now pushing the dev images depended on the name of the
deployment.

But this task was failing for deployments which were not done on a
cluster started with 'oc cluster up', but with 'minishift', for example.

Instead of relying on the name of the deployment to decide whether to
push the dev images, create a dedicated flag, to allow disabling this
task even when the deployment is done on an environment called 'dev' but
not on a cluster started with 'oc cluster up'.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>