### PR TITLE
[secrets/template/extra-vars.yml] don't set aws keys

### DIFF
--- a/secrets/template/extra-vars.yml
+++ b/secrets/template/extra-vars.yml
@@ -2,8 +2,10 @@ postgres_user: <user>
 postgres_password: <passwd>
 postgres_host: <instance hostname>
 postgres_database_name: <db name>
-aws_access_key_id: <AWS access key ID, set to "" if you don't want to use AWS SQS>
-aws_secret_access_key: <AWS secret access key, set to "" if you don't want to use AWS SQS>
+# AWS access key ID, set to "" if you don't want to use AWS SQS
+aws_access_key_id: ""
+# AWS secret access key, set to "" if you don't want to use AWS SQS
+aws_secret_access_key: ""
 redis_commander_user: <user>
 redis_commander_password: <passwd>
 flower_basic_auth: <user>:<passwd>[,<user>:<passwd>]


### PR DESCRIPTION
If we had #68 we'd already know that [p-s uses the template](https://github.com/packit/packit-service/blob/master/files/deployment.yaml#L93) in `make check-inside-openshift`.