### PR TITLE
[worker] Run probes only if not using AWS SQS

### DIFF
--- a/openshift/packit-service-worker.yml.j2
+++ b/openshift/packit-service-worker.yml.j2
@@ -139,7 +139,8 @@ spec:
               command:
                 - bash
                 - -c
-                - "celery -A $APP status | grep $(cat /etc/hostname) | grep OK"
+                # if we don't use AWS SQS (doesn't support this)
+                - 'if (test -z "$AWS_ACCESS_KEY_ID"); then celery -A $APP status | grep $(cat /etc/hostname) | grep OK; else true; fi'
             initialDelaySeconds: 10
             periodSeconds: 60
           livenessProbe:
@@ -148,7 +149,7 @@ spec:
                 - bash
                 - -c
                 # does this worker respond to ping?
-                - 'celery -A $APP inspect ping --destination "celery@$(cat /etc/hostname)"'
+                - 'if (test -z "$AWS_ACCESS_KEY_ID"); then celery -A $APP inspect ping --destination "celery@$(cat /etc/hostname)"; else true; fi'
             initialDelaySeconds: 10
             periodSeconds: 30
 ---


### PR DESCRIPTION
[SQS does not support broadcast](https://docs.celeryproject.org/en/latest/getting-started/brokers/index.html#broker-overview) and `celery status/inspect` results in `Error: Broadcast not supported by transport 'sqs'`