### PR TITLE
Comment out worker probes

### DIFF
--- a/openshift/packit-service-worker.yml.j2
+++ b/openshift/packit-service-worker.yml.j2
@@ -134,24 +134,25 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "800m"
-          readinessProbe:
-            exec:
-              command:
-                - bash
-                - -c
-                # if we don't use AWS SQS (doesn't support this)
-                - 'if (test -z "$AWS_ACCESS_KEY_ID"); then celery -A $APP status | grep $(cat /etc/hostname) | grep OK; else true; fi'
-            initialDelaySeconds: 10
-            periodSeconds: 60
-          livenessProbe:
-            exec:
-              command:
-                - bash
-                - -c
-                # does this worker respond to ping?
-                - 'if (test -z "$AWS_ACCESS_KEY_ID"); then celery -A $APP inspect ping --destination "celery@$(cat /etc/hostname)"; else true; fi'
-            initialDelaySeconds: 10
-            periodSeconds: 30
+          # https://github.com/packit/deployment/pull/142
+          #readinessProbe:
+          #  exec:
+          #    command:
+          #      - bash
+          #      - -c
+          #      # if we don't use AWS SQS (doesn't support this)
+          #      - 'if (test -z "$AWS_ACCESS_KEY_ID"); then celery -A $APP status | grep $(cat /etc/hostname) | grep OK; else true; fi'
+          #  initialDelaySeconds: 10
+          #  periodSeconds: 60
+          #livenessProbe:
+          #  exec:
+          #    command:
+          #      - bash
+          #      - -c
+          #      # does this worker respond to ping?
+          #      - 'if (test -z "$AWS_ACCESS_KEY_ID"); then celery -A $APP inspect ping --destination "celery@$(cat /etc/hostname)"; else true; fi'
+          #  initialDelaySeconds: 10
+          #  periodSeconds: 30
 ---
 # https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#writing-image-stream-definitions
 kind: ImageStream


### PR DESCRIPTION
- [we can't install celery from RPM](https://github.com/packit/packit-service/blob/master/files/install-deps-worker.yaml#L22)
- [we can't install pycurl from RPM](https://github.com/packit/packit-service/pull/823)
- [base image has to stay with Fedora-31](https://github.com/packit/packit-service/pull/822#issuecomment-696043755)
- [the probes don't work with SQS](https://github.com/packit/deployment/pull/135)
- [the readiness probe sometimes takes a looong time](https://github.com/packit/deployment/pull/135#issuecomment-691953962)
- Are they a reliable indicator of the workers health? Don't they actually tell us more about the broker's health?

I know it's a good practice to have the probes, but I have enough of trying to `pip install pycurl`, because we can't install it and celery with dnf - because of the probes.