### PR TITLE
Use Prometheus Aggregation Gateway instead of Pushgateway

### DIFF
--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -15,24 +15,14 @@ spec:
         name: pushgateway
         app: packit
     spec:
-      volumes:
-        - name: pushgateway-data
-          persistentVolumeClaim:
-            claimName: pushgateway-data
       containers:
         - name: pushgateway
-        # https://hub.docker.com/r/prom/pushgateway/tags
-          image: prom/pushgateway:v1.2.0
+          image: weaveworks/prom-aggregation-gateway
           args:
-            - "--web.listen-address=:9091"
-            - "--persistence.file=/data/pushgateway"
-            - "--persistence.interval=1m"
+            - "--listen=:9091"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9091
-          volumeMounts:
-            - mountPath: /data
-              name: pushgateway-data
           resources:
             limits:
               cpu: "50m"
@@ -55,14 +45,3 @@ spec:
       port: 80
       protocol: TCP
       targetPort: 9091
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: pushgateway-data
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -300,7 +300,7 @@
         - tokman
       register: tokman
 
-    - name: Deploy prometheus pushgateway
+    - name: Deploy aggregating pushgateway
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '../openshift/pushgateway.yml.j2')  }}"


### PR DESCRIPTION
Since the [counter for Copr builds](https://github.com/packit/packit-service/pull/827) is rewritten with each push (so the value is always 1, see [metrics](https://workers.stg.packit.dev/metrics)) when using Pushgateway, I checked for similar issues and found [Prometheus Aggregation Gateway](https://github.com/weaveworks/prom-aggregation-gateway) which could better fit our use case. Tried it locally, it doesn't support the `persistence.file` and `persistence.interval` args, but otherwise worked well.