### PR TITLE
[secrets/template/packit-service.yaml] remove disable_sentry

### DIFF
--- a/secrets/template/packit-service.yaml
+++ b/secrets/template/packit-service.yaml
@@ -21,8 +21,6 @@ webhook_secret: <webhook_secret>
 testing_farm_secret: <testing_farm>
 gitlab_token_secret: <gitlab-token-secret>
 
-disable_sentry: True
-
 command_handler: sandcastle
 command_handler_work_dir: /sandcastle
 command_handler_image_reference: docker.io/usercont/sandcastle


### PR DESCRIPTION
This was added in https://github.com/packit/deployment/pull/77 due to https://github.com/packit/packit-service/pull/561 but 
reverted in https://github.com/packit/packit-service/pull/571

I need this because [marshmallow-3 now screams](https://github.com/packit/packit-service/pull/826) that it's unknown field.