### PR TITLE
Update pre-commit configuration for prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@
 # pre-commit install
 
 repos:
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.1
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -61,7 +61,6 @@
     - name: Getting DCs
       include_tasks: tasks/set-facts.yml
 
-
       # to be able to read the github_app_id from the configuration file in tokman
     - name: include packit-service configuration
       include_vars:


### PR DESCRIPTION
In order to solve this installation issue:

https://github.com/prettier/prettier/issues/9459

It seems that prettier is moving the pre-commit parts in a separate
repository.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>