### PR TITLE
Add script for moving stable branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ secrets/dev
 secrets/secrets.yaml
 
 # used in move_stable script
-scripts/repositories
+move_stable_repositories

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ secrets/stg
 secrets/dev
 
 secrets/secrets.yaml
+
+# used in move_stable script
+scripts/repositories

--- a/scripts/move_stable.py
+++ b/scripts/move_stable.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import click
+
+# import ogr
+
+import os
+import subprocess
+from typing import List
+
+
+NAMESPACE: str = "packit"
+REPOSITORIES: List[str] = [
+    "packit",
+    "packit-service-fedmsg",
+    "packit-service-centosmsg",
+    "sandcastle",
+    "dashboard",
+    "tokman",
+    "packit-service",
+]
+# TESTING_REPOSITORY: str = "hello-world"
+STABLE_BRANCH: str = "stable"
+ROLLING_BRANCH: str = "master"
+
+
+@click.group()
+def cli() -> None:
+    pass
+
+
+@cli.command(short_help="Creates a directory with all the repositories")
+def init() -> None:
+    os.makedirs("repositories", exist_ok=True)
+
+    for repository in REPOSITORIES:
+        subprocess.run(
+            ["git", "clone", f"github.com:{NAMESPACE}/{repository}.git"],
+            cwd=f"{os.curdir}/repositories",
+        )
+
+
+@cli.command(short_help=f"Moves all {STABLE_BRANCH}s interactively")
+def move_all() -> None:
+    remote = "origin"
+
+    for repository in REPOSITORIES:
+        click.secho(f"==> Moving {repository}", fg="yellow")
+        path_to_repository = f"{os.curdir}/repositories/{repository}"
+
+        fetch_all(path_to_repository)
+
+        main_hash = get_reference(path_to_repository, remote, ROLLING_BRANCH)
+        stable_hash = get_reference(path_to_repository, remote, STABLE_BRANCH)
+
+        if main_hash == stable_hash:
+            click.echo(
+                f"===> {ROLLING_BRANCH} and {STABLE_BRANCH} are even for {NAMESPACE}/{repository} => Skipping"
+            )
+            continue
+
+        get_git_log(path_to_repository, remote, stable_hash, main_hash)
+        click.echo()
+
+        new_stable_hash = click.prompt(
+            f"Enter new hash for {STABLE_BRANCH}", default=main_hash
+        )
+
+        push_stable_branch(path_to_repository, new_stable_hash)
+        click.echo()
+
+
+# @cli.command(short_help="Prints out status of selected pull requests")
+# def status():
+#     service = ogr.GithubService(token=os.environ.get("GITHUB_TOKEN"))
+#     project = service.get_project(namespace=NAMESPACE, repo=TESTING_REPOSITORY)
+
+#     testing_prs = list(
+#         filter(
+#             lambda pr: "should pass" in map(lambda label: label.name, pr.labels),
+#             project.get_pr_list(),
+#         )
+#     )
+
+#     for pr in testing_prs:
+#         print(pr.title, pr.get_statuses())
+
+
+def get_reference(path_to_repository: str, remote: str, branch: str) -> str:
+    return (
+        subprocess.run(
+            [
+                "git",
+                "show-ref",
+                "-s",
+                f"{remote}/{branch}",
+            ],
+            cwd=path_to_repository,
+            capture_output=True,
+        )
+        .stdout.strip()
+        .decode("utf-8")
+    )
+
+
+def fetch_all(path_to_repository: str) -> None:
+    click.echo("===> Fetching")
+    subprocess.run(
+        ["git", "fetch", "--all"], cwd=path_to_repository, capture_output=True
+    )
+
+
+def get_git_log(
+    path_to_repository: str, remote: str, hash_from: str, hash_to: str
+) -> None:
+    click.echo(
+        f"===> Commits since {STABLE_BRANCH} ({hash_from[:7]}) till "
+        f"HEAD of {ROLLING_BRANCH} ({hash_to[:7]})\n"
+    )
+    subprocess.run(
+        ["git", "--no-pager", "log", "--oneline", "--graph", f"{hash_from}..{hash_to}"],
+        cwd=path_to_repository,
+    )
+
+
+def push_stable_branch(path_to_repository: str, commit_sha: str) -> None:
+    click.echo(f"New HEAD of {STABLE_BRANCH}: {commit_sha}")
+    if click.confirm(
+        click.style("Is that correct?", fg="red", blink=True), default=True
+    ):
+        subprocess.run(
+            ["git", "branch", "-f", STABLE_BRANCH, commit_sha], cwd=path_to_repository
+        )
+
+        subprocess.run(["git", "push", "origin", STABLE_BRANCH], cwd=path_to_repository)
+    else:
+        click.echo(f"===> Not moving {STABLE_BRANCH} branch")
+
+
+if __name__ == "__main__":
+    cli()

--- a/scripts/move_stable.py
+++ b/scripts/move_stable.py
@@ -37,7 +37,7 @@ def init() -> None:
 
     for repository in REPOSITORIES:
         subprocess.run(
-            ["git", "clone", f"github.com:{NAMESPACE}/{repository}.git"],
+            ["git", "clone", f"git@github.com:{NAMESPACE}/{repository}.git"],
             cwd=f"{os.curdir}/move_stable_repositories",
         )
 
@@ -52,8 +52,8 @@ def move_all() -> None:
 
         fetch_all(path_to_repository)
 
-        main_hash = get_reference(path_to_repository, remote, ROLLING_BRANCH)
-        stable_hash = get_reference(path_to_repository, remote, STABLE_BRANCH)
+        main_hash = get_reference(path_to_repository, remote, ROLLING_BRANCH)[:7]
+        stable_hash = get_reference(path_to_repository, remote, STABLE_BRANCH)[:7]
 
         if main_hash == stable_hash:
             click.echo(
@@ -116,8 +116,8 @@ def get_git_log(
     path_to_repository: str, remote: str, hash_from: str, hash_to: str
 ) -> None:
     click.echo(
-        f"===> Commits since {STABLE_BRANCH} ({hash_from[:7]}) till "
-        f"HEAD of {ROLLING_BRANCH} ({hash_to[:7]})\n"
+        f"===> Commits since {STABLE_BRANCH} ({hash_from}) till "
+        f"HEAD of {ROLLING_BRANCH} ({hash_to})\n"
     )
     subprocess.run(
         ["git", "--no-pager", "log", "--oneline", "--graph", f"{hash_from}..{hash_to}"],

--- a/scripts/move_stable.py
+++ b/scripts/move_stable.py
@@ -33,12 +33,12 @@ def cli() -> None:
 
 @cli.command(short_help="Creates a directory with all the repositories")
 def init() -> None:
-    os.makedirs("repositories", exist_ok=True)
+    os.makedirs("move_stable_repositories", exist_ok=True)
 
     for repository in REPOSITORIES:
         subprocess.run(
             ["git", "clone", f"github.com:{NAMESPACE}/{repository}.git"],
-            cwd=f"{os.curdir}/repositories",
+            cwd=f"{os.curdir}/move_stable_repositories",
         )
 
 
@@ -48,7 +48,7 @@ def move_all() -> None:
 
     for repository in REPOSITORIES:
         click.secho(f"==> Moving {repository}", fg="yellow")
-        path_to_repository = f"{os.curdir}/repositories/{repository}"
+        path_to_repository = f"{os.curdir}/move_stable_repositories/{repository}"
 
         fetch_all(path_to_repository)
 


### PR DESCRIPTION
Signed-off-by: Matej Focko <mfocko@redhat.com>

Dependency: `click`

As a remote uses: `github.com:namespace/repo.git` (expects SSH key to be set up)

1. `scripts/move_stable.py init` creates a directory and clones all git repositories with stable branch into it (ran only once)
   - resolves ambiguity of remotes `upstream` vs `origin` vs _any-other-creative-name_
   - all repos have same prefix for their path
2. `scripts/move_stable.py move-all`
   - runs git fetch
   - prints out log from stable to master (there's also hash of stable in case of removing the confirmation before moving)
   - automatically takes hash from master, but allows to input hash manually (I should add checking for invalid hash too)

- can be run from either the root of `deployment` or `scripts` directory (not interchangeable, `init` is specific to the directory), directory with repositories added to gitignore
- there's also mock-up of `status` command, I've hit API rate limit without token instantly; used token, I wasn't patient enough to wait for results
   My intention was to take commit statuses of PRs with periodic checks (labelled them with `should pass`) and print / guess last commit hash that could've been tested and print all hung / failed commit statuses
- Also I plan to clean up the running of git

---
_almost moved the stable while testing_