### PR TITLE
set prod worker replicas to 2

### DIFF
--- a/vars/prod_template.yml
+++ b/vars/prod_template.yml
@@ -76,7 +76,7 @@ validate_certs: yes
 # image_tokman: "docker.io/usercont/tokman:{{ deployment }}"
 
 # Number of worker pods to be deployed
-worker_replicas: 3
+worker_replicas: 2
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 


### PR DESCRIPTION
I recall we had set it to 3 back then when the build job was one big
task. This is no longer the case as the job was broke down to multiple
subtasks.

The longest task we have right now is the creation of an SRPM which for
packit e.g. takes ~2 minutes:

https://prod.packit.dev/srpm-build/12474/logs

Over the past few weeks I haven't seen a case where 3 SRPM builds were
running at the same time - I have no hard data though.

I feel like we can reduce the # of worker replica to 2 and save some
memory (it's even possible that 3 SRPM builds can't run at the same time
b/c of the timebound memory quota).

The worst case which can happen is that all workers would be busy with
SRPM builds and packit could be slow with setting initial statuses.