### PR TITLE
set worker memory to 512Mi

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -129,7 +129,7 @@ spec:
             - "/usr/bin/run_worker.sh"
           resources:
             limits:
-              memory: "384Mi"
+              memory: "512Mi"
               cpu: "400m"
           # https://github.com/packit/deployment/pull/142
           #readinessProbe:


### PR DESCRIPTION
it's an increase by 128M

This change is done so we can clone bigger repos such as glibc or kernel-ark
source-git repos:
https://gitlab.com/packit-service/src/glibc.git

Sadly, one cannot verify this easily locally because there are multiple
processes in worker aside from just bash and git when trying this in a
container. Though I verified that glibc can be cloned with 256M and can't with
128M:

```
$ sudo podman run --rm -ti --memory 256mb docker.io/usercont/packit-worker:prod bash
bash-5.0# git clone https://gitlab.com/packit-service/src/glibc.git
Cloning into 'glibc'...
remote: Enumerating objects: 501438, done.
remote: Total 501438 (delta 0), reused 0 (delta 0), pack-reused 501438
Receiving objects: 100% (501438/501438), 200.76 MiB | 15.62 MiB/s, done.
Resolving deltas: 100% (428395/428395), done.
Updating files: 100% (17068/17068), done.

$ sudo podman run --rm -ti --memory 128mb docker.io/usercont/packit-worker:prod bash
bash-5.0# git clone https://gitlab.com/packit-service/src/glibc.git
Cloning into 'glibc'...
remote: Enumerating objects: 501438, done.
Receiving objects: 100% (501438/501438), 200.76 MiB | 16.99 MiB/s, done.
remote: Total 501438 (delta 0), reused 0 (delta 0), pack-reused 501438
error: index-pack died of signal 9395)
fatal: index-pack failed
```