### PR TITLE
[.github/workflows/base-image-rebuild] run on push to main

### DIFF
--- a/.github/workflows/base-image-rebuild.yml
+++ b/.github/workflows/base-image-rebuild.yml
@@ -3,11 +3,16 @@ on:
   schedule:
     # At 00:00 on Monday.
     - cron: "0 0 * * 1"
+  push:
+    branches:
+      - main
+    paths:
+      - containers/Dockerfile.base
 
 jobs:
   build:
     # To not run in forks
-    if: github.repository == 'packit/deployment'
+    if: github.repository_owner == 'packit'
 
     name: Build and push image
     runs-on: ubuntu-latest
@@ -29,5 +34,5 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
           registry: quay.io/packit
-          username: ${{ secrets.QUAY_BASE_IMAGE_BUILDER_USERNAME }}
-          password: ${{ secrets.QUAY_BASE_IMAGE_BUILDER_TOKEN }}
+          username: ${{ secrets.QUAY_IMAGE_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_IMAGE_BUILDER_TOKEN }}


### PR DESCRIPTION
so that the base image is rebuilt also when its Dockerfile changes.

Use organization level secrets instead of local repo secrets.