### PR TITLE
Use rhel8 based redis & postgres from registry.redhat.io

### DIFF
--- a/openshift/postgres.yml
+++ b/openshift/postgres.yml
@@ -53,7 +53,7 @@ spec:
                 secretKeyRef:
                   key: database-name
                   name: postgres-secret
-          image: registry.access.redhat.com/rhscl/postgresql-10-rhel7
+          image: registry.redhat.io/rhel8/postgresql-10
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:

--- a/openshift/redis.yml
+++ b/openshift/redis.yml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: registry.fedoraproject.org/f31/redis
+          image: registry.redhat.io/rhel8/redis-5
           ports:
             - containerPort: 6379
           volumeMounts:


### PR DESCRIPTION
Postgresql:
- https://catalog.redhat.com/software/containers/rhscl/postgresql-10-rhel7/5aa63541ac3db95f196086f1
- https://catalog.redhat.com/software/containers/rhel8/postgresql-10/5ba0ae0ddd19c70b45cbf4cd
- The rhscl/postgresql-10-rhel7 container image reaches its end of life in May 2021.
- Both images contain postgresql-10.15

Redis:
- https://catalog.redhat.com/software/containers/rhel8/redis-5/5c401b0cbed8bd75a2c4c287
- Redis image @ registry.fedoraproject.org was in the past updated only on our demand.
- The fedora based image contains redis-5.0.7, while the rhel8 based contains redis-5.0.3 with patches. (Hopefully, there was no backwards incompatible change between 5.0.3 and 5.0.7)