### PR TITLE
delete-pvcs now deletes PVCs from any Completed pods

### DIFF
--- a/cron-jobs/delete-pvcs/README.md
+++ b/cron-jobs/delete-pvcs/README.md
@@ -1,6 +1,6 @@
-## Periodically deleting old persistentvolumeclaims (PVCs)
+## Periodically deleting old Persistent Volume Claims (PVCs)
 
-[It happens from time to time](https://github.com/packit-service/packit-service/issues/409) that leftover PVCs in a sandbox namespace consume all storage quota.
+[It happens from time to time](https://github.com/packit/packit-service/issues/409) that leftover PVCs in a sandbox namespace consume all storage quota.
 
 As a work-around, here's a CronJob to periodically delete old PVCs.
 See CronJob definition [job-delete-pvcs.yaml](./job-delete-pvcs.yaml) or `oc describe cronjob/delete-pvcs`.

--- a/cron-jobs/delete-pvcs/delete-pvcs.sh
+++ b/cron-jobs/delete-pvcs/delete-pvcs.sh
@@ -12,13 +12,21 @@ POD_NAME_STARTSWITH="quay-io-packit-sandcastle-${DEPLOYMENT}-"
 oc get pod -n "${NAMESPACE}" | grep "^${POD_NAME_STARTSWITH}" |
 # for each pod
 while IFS= read -r line; do
-  pod_name=$(echo "${line}" | awk '{print $1}')
   pod_status=$(echo "${line}" | awk '{print $3}')
   if [ "${pod_status}" == "Completed" ];
   then
+    pod_name=$(echo "${line}" | awk '{print $1}')
+    pod_age=$(echo "${line}" | awk '{print $5}')
+
     # get associated PVC name
     pvc_name=$(oc get pod "${pod_name}" -n "${NAMESPACE}" -o=jsonpath="{.spec.volumes[0].persistentVolumeClaim.claimName}")
-    echo "Deleting ${pvc_name}"
+    echo "Deleting pvc ${pvc_name}"
     oc delete pvc "${pvc_name}" -n "${NAMESPACE}"
+
+    if [ "${pod_age: -1}" == "d" ]; # days
+    then
+      echo "Deleting pod ${pod_name}"
+      oc delete pod "${pod_name}" -n "${NAMESPACE}"
+    fi
   fi
 done

--- a/cron-jobs/delete-pvcs/delete-pvcs.sh
+++ b/cron-jobs/delete-pvcs/delete-pvcs.sh
@@ -5,15 +5,20 @@ oc login "${HOST}" --token="${TOKEN}"
 set -x
 
 DEFAULT_NAMESPACE="packit-${DEPLOYMENT}-sandbox"
-SANDBOX_NAMESPACE="${SANDBOX_NAMESPACE:-$DEFAULT_NAMESPACE}"
+NAMESPACE="${SANDBOX_NAMESPACE:-$DEFAULT_NAMESPACE}"
+POD_NAME_STARTSWITH="quay-io-packit-sandcastle-${DEPLOYMENT}-"
 
-oc get pvc -n "${SANDBOX_NAMESPACE}" |
+# get all pods with name starting with POD_NAME_STARTSWITH
+oc get pod -n "${NAMESPACE}" | grep "^${POD_NAME_STARTSWITH}" |
+# for each pod
 while IFS= read -r line; do
-  age=$(echo "${line}" | awk '{print $7}')
-  if [ "${age: -1}" == "d" ]; # days
+  pod_name=$(echo "${line}" | awk '{print $1}')
+  pod_status=$(echo "${line}" | awk '{print $3}')
+  if [ "${pod_status}" == "Completed" ];
   then
-    name=$(echo "${line}" | awk '{print $1}')
-    echo "deleting ${name}"
-    oc delete pvc "${name}" -n "${SANDBOX_NAMESPACE}"
+    # get associated PVC name
+    pvc_name=$(oc get pod "${pod_name}" -n "${NAMESPACE}" -o=jsonpath="{.spec.volumes[0].persistentVolumeClaim.claimName}")
+    echo "Deleting ${pvc_name}"
+    oc delete pvc "${pvc_name}" -n "${NAMESPACE}"
   fi
 done


### PR DESCRIPTION
Previously we deleted only PVCs older than a day.
Now we delete all PVCs associated with pods in the Completed state.

EDIT: And also delete pods older than a day.

Fixes #192