### PR TITLE
base image: run 'dnf update'

### DIFF
--- a/containers/Dockerfile.base
+++ b/containers/Dockerfile.base
@@ -7,4 +7,6 @@ ENV LANG=en_US.UTF-8 \
     ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug
 
-RUN dnf install -y ansible python3-pip && dnf clean all
+RUN dnf update -y && \
+    dnf install -y ansible python3-pip && \
+    dnf clean all


### PR DESCRIPTION
It makes the image bigger (+165MB), but having all packages updated is IMHO worth it.

We re-build the base image every Monday, so in case the update breaks anything, we have time till Friday to realize that, before we build prod images on top of it.