### PR TITLE
move-stable: Allow choosing a custom repo store

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,7 @@ repos:
     hooks:
       - id: ansible-lint
         files: \.(yaml|yml)$
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black

--- a/cron-jobs/serve-acme-challenge.py
+++ b/cron-jobs/serve-acme-challenge.py
@@ -15,7 +15,7 @@ class ACMEHandler(BaseHTTPRequestHandler):
             self.send_response(404)
         else:
             self.send_response(200)
-        self.send_header('Content-type', 'text/plain')
+        self.send_header("Content-type", "text/plain")
         self.end_headers()
         self.wfile.write(content.encode())
 

--- a/cron-jobs/validation/packit-service-validation.py
+++ b/cron-jobs/validation/packit-service-validation.py
@@ -17,9 +17,7 @@ from ogr.abstract import PullRequest
 copr = Client.create_from_config_file()
 service = GithubService(token=getenv("GITHUB_TOKEN"))
 project = service.get_project(repo="hello-world", namespace="packit")
-user = InputGitAuthor(
-    name="Release Bot", email="user-cont-team+release-bot@redhat.com"
-)
+user = InputGitAuthor(name="Release Bot", email="user-cont-team+release-bot@redhat.com")
 
 
 class Trigger(str, enum.Enum):
@@ -42,9 +40,7 @@ class Testcase:
         :return:
         """
         if self.pr and not self._copr_project_name:
-            self._copr_project_name = (
-                f"packit-hello-world-{self.pr.id}"
-            )
+            self._copr_project_name = f"packit-hello-world-{self.pr.id}"
         return self._copr_project_name
 
     def run_test(self):
@@ -106,14 +102,16 @@ class Testcase:
             # if the source branch does not exist, create one
             # and create a commit
             commit = project.github_repo.get_commit("HEAD")
-            project.github_repo.create_git_ref(f"refs/heads/{source_branch}", commit.sha)
+            project.github_repo.create_git_ref(
+                f"refs/heads/{source_branch}", commit.sha
+            )
             project.github_repo.create_file(
                 path="test.txt",
                 message="Opened PR trigger",
                 content="Testing the opened PR trigger.",
                 branch=source_branch,
                 committer=user,
-                author=user
+                author=user,
             )
 
         existing_pr = [pr for pr in project.get_pr_list() if pr.title == pr_title]
@@ -155,8 +153,7 @@ class Testcase:
 
         watch_end = datetime.now() + timedelta(seconds=60)
         failure_message = (
-            "Github statuses were not set "
-            "to pending in time 1 minute.\n"
+            "Github statuses were not set " "to pending in time 1 minute.\n"
         )
 
         # when a new PR is opened

--- a/scripts/setupcfg2rpm.py
+++ b/scripts/setupcfg2rpm.py
@@ -42,14 +42,15 @@ import configparser
 
 def normalize_name(name: str) -> str:
     """https://www.python.org/dev/peps/pep-0503/#normalized-names"""
-    return re.sub(r'[-_.]+', '-', name).lower()
+    return re.sub(r"[-_.]+", "-", name).lower()
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description='Parse rpm requirements from setup.cfg from section '
-                    '[options], key install_requires')
-    parser.add_argument('path', type=str, help='Path to setup.cfg')
+        description="Parse rpm requirements from setup.cfg from section "
+        "[options], key install_requires"
+    )
+    parser.add_argument("path", type=str, help="Path to setup.cfg")
 
     args = parser.parse_args()
     setupcfg_path = pathlib.Path(args.path)
@@ -59,6 +60,8 @@ if __name__ == "__main__":
         config.read_file(f)
         python_packages = config["options"]["install_requires"].strip().splitlines()
 
-    result = [f"python3dist({normalize_name(pkg_name)})" for pkg_name in python_packages]
+    result = [
+        f"python3dist({normalize_name(pkg_name)})" for pkg_name in python_packages
+    ]
 
     print(os.linesep.join(result))


### PR DESCRIPTION
So far the 'move_stable_repositories' directory was hard-coded throughout
the script. Add a --repo-store option to be able to customise this.

Also:
- use pathlib.Path everywhere to work with paths;
- improve help texts and validation of options and arguments;
- make repository and argument for move-repository, instead of an option
  (it feels more natural);
- enable 'black' in the pre-commit config.