### PR TITLE
make: sugest to run 'import-images' with 'deploy'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=
 # https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags
 TAGS ?= all
 
+# Consider running 'make import-images' to avoid possible 'Error: ImagePullBackOff'
+# in case of newer, not-yet-imported images.
 deploy:
 	$(AP) playbooks/deploy.yml --tags $(TAGS)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ For more details about local builds see [packit-service/CONTRIBUTING.md](https:/
 tl;dr: Newer images in registry are automatically imported and re-deployed.
 
 Long story:
-We use [ImageStreams](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#image-streams) as intermediary between an image registry (Docker Hub) and a Deployment/StatefulSet. It has several significant benefits:
+We use [ImageStreams](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#image-streams)
+as intermediary between an image registry (Quay.io) and a Deployment/StatefulSet.
+It has several significant benefits:
 
 - We can automatically trigger Deployment when a new image is pushed to the registry.
 - We can rollback/revert/undo the Deployment (previously we had to use image digests to achieve this).


### PR DESCRIPTION
Quay.io seems to keep only the latest image build in each repo.
In case we build a new image and run 'make deploy' without
the image being imported first, we get 'Error: ImagePullBackOff'.
The workaround is to run 'make import-images' as well.