### PR TITLE
Add persistent volume for repository cache

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -47,6 +47,16 @@ spec:
         resources:
           requests:
             storage: 2Gi
+    - metadata:
+        name: packit-worker-repository-cache
+      spec:
+        # The only option on OpenShift Online is AWS EBS provisioning
+        # supporting only `ReadWriteOnce` access:
+        # https://docs.openshift.com/online/pro/architecture/additional_concepts/storage.html#pv-restrictions
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 16Gi
   updateStrategy.type: RollingUpdate
   podManagementPolicy: OrderedReady
   template:
@@ -133,6 +143,8 @@ spec:
               mountPath: /home/packit/.config
             - name: packit-worker-vol
               mountPath: /sandcastle
+            - name: packit-worker-repository-cache
+              mountPath: /repository-cache
           command:
             - "/usr/bin/run_worker.sh"
           resources:

--- a/openshift/sandcastle-volumes-for-cache.yml.j2
+++ b/openshift/sandcastle-volumes-for-cache.yml.j2
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: "sandcastle-repository-cache-{{ name }}"
+spec:
+  # The only option on OpenShift Online is AWS EBS provisioning
+  # supporting only `ReadWriteOnce` access:
+  # https://docs.openshift.com/online/pro/architecture/additional_concepts/storage.html#pv-restrictions
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 16Gi

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -155,6 +155,18 @@
       tags:
         - packit-service
 
+    - name: Deploy repository cache PVCs for packit-workers that serves both queues
+      vars:
+        name: "packit-worker-{{ item }}"
+      k8s:
+        namespace: "{{ sandbox_namespace }}"
+        definition: "{{ lookup('template', '{{ project_dir }}/openshift/sandcastle-volumes-for-cache.yml.j2') }}"
+        host: "{{ host }}"
+        api_key: "{{ api_key }}"
+        validate_certs: "{{ validate_certs }}"
+      loop: "{{ range(0, workers_all_tasks)|list }}"
+      when: workers_all_tasks > 0
+
     - name: Deploy packit-worker to serve both queues
       vars:
         name: packit-worker
@@ -170,6 +182,18 @@
         - packit-worker
       when: workers_all_tasks > 0
 
+    - name: Deploy repository cache PVCs for packit-workers that serves short-running queue
+      vars:
+        name: "packit-worker-short-running-{{ item }}"
+      k8s:
+        namespace: "{{ sandbox_namespace }}"
+        definition: "{{ lookup('template', '{{ project_dir }}/openshift/sandcastle-volumes-for-cache.yml.j2') }}"
+        host: "{{ host }}"
+        api_key: "{{ api_key }}"
+        validate_certs: "{{ validate_certs }}"
+      loop: "{{ range(0, workers_short_running)|list }}"
+      when: workers_short_running > 0
+
     - name: Deploy packit-worker to serve short-running queue
       vars:
         name: packit-worker-short-running
@@ -184,6 +208,18 @@
       tags:
         - packit-worker
       when: workers_short_running > 0
+
+    - name: Deploy repository cache PVCs for packit-workers that serves long-running queue
+      vars:
+        name: "packit-worker-long-running-{{ item }}"
+      k8s:
+        namespace: "{{ sandbox_namespace }}"
+        definition: "{{ lookup('template', '{{ project_dir }}/openshift/sandcastle-volumes-for-cache.yml.j2') }}"
+        host: "{{ host }}"
+        api_key: "{{ api_key }}"
+        validate_certs: "{{ validate_certs }}"
+      loop: "{{ range(0, workers_long_running)|list }}"
+      when: workers_long_running > 0
 
     - name: Deploy packit-worker to serve long-running queue
       vars:

--- a/roles/generate-secrets/templates/packit-service.yaml.j2
+++ b/roles/generate-secrets/templates/packit-service.yaml.j2
@@ -25,6 +25,14 @@ command_handler: {{ command_handler }}
 command_handler_work_dir: /sandcastle
 command_handler_image_reference: quay.io/packit/sandcastle
 command_handler_k8s_namespace: packit-dev-sandbox
+command_handler_pvc_volume_specs:
+  - path: /repository-cache
+    pvc_from_env: SANDCASTLE_REPOSITORY_CACHE_VOLUME
+
+repository_cache: /repository-cache
+# The maintenance of the cache (adding, updating) is done externally,
+# not in the packit/packit-service code.
+add_repositories_to_repository_cache: false
 
 server_name: "{{ server_hostname }}:{{ server_port }}"
 dashboard_url: "https://{{ server_hostname }}:{{ server_port }}"


### PR DESCRIPTION
Add persistent volume to the worker for repository-cache.
    
* The only option on OpenShift Online is AWS EBS provisioning
   supporting only `ReadWriteOnce` access:
   https://docs.openshift.com/online/pro/architecture/additional_concepts/storage.html#pv-restrictions  
   Because of that, we need to have one repository-cache for each worker.
    
* The volume is mounted to /repository-cache path.
* For now, the content of the cache will be maintained (adding/updating) manually.