### PR TITLE
Skip ansible-lint in pre-commit.ci since it is too huge

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,7 @@ repos:
     rev: 21.5b1
     hooks:
       - id: black
+
+ci:
+  # The project is too huge for pre-commit.ci
+  skip: [ansible-lint]


### PR DESCRIPTION
* With ansible-lint pre-commit.ci does not work at all.
* We still have zuul to run the whole suite.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>