### PR TITLE
[validation] update PR object after push

### DIFF
--- a/cron-jobs/validation/packit-service-validation.py
+++ b/cron-jobs/validation/packit-service-validation.py
@@ -88,6 +88,8 @@ class Testcase:
             committer=user,
             author=user,
         )
+        # udpate the PR object so that the head commit is up to date
+        self.pr = project.get_pr(self.pr.id)
 
     def create_pr(self):
         """


### PR DESCRIPTION
Since the PR object stores the head commit value, after the new commit push we get the statuses from the old head commit, therefore the PR object needs to be updated after the push.