### PR TITLE
[validation] fix the head commit when there is no PR yet

### DIFF
--- a/cron-jobs/validation/packit-service-validation.py
+++ b/cron-jobs/validation/packit-service-validation.py
@@ -33,7 +33,7 @@ class Testcase:
         self.pr = pr
         self.failure_msg = ""
         self.trigger = trigger
-        self.head_commit = pr.head_commit
+        self.head_commit = pr.head_commit if pr else None
         self._copr_project_name = None
 
     @property
@@ -128,6 +128,7 @@ class Testcase:
             target_branch=project.default_branch,
             source_branch=source_branch,
         )
+        self.head_commit = self.pr.head_commit
 
     def run_checks(self):
         """


### PR DESCRIPTION
This was a hotfix of https://sentry.io/organizations/red-hat-0p/issues/2421608064/?project=1767823&query=head_commit&statsPeriod=14d, so it's already updated in the image and running for over a week (just forgot to push the change).

When we do the test for opened PR trigger, the PR object is initialized later, therefore the `'NoneType' object has no attribute 'head_commit'`.