### PR TITLE
[validation] monitor check runs instead of commit statuses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,8 @@ vars/**/*.yml
 .idea/
 .DS_Store
 
-secrets/prod
-secrets/stg
-secrets/dev
-
+secrets/packit/
+secrets/stream/
 secrets/secrets.yaml
 
 # used in move_stable script


### PR DESCRIPTION
On Monday, the check runs should land in production, so this should be then merged and the image rebuilt, so that the script monitors check runs and not commit statuses.
I lowered some time limits, for submitting and completng of Copr build.