### PR TITLE
Improve deleting stale sandbox PVCs

### DIFF
--- a/cron-jobs/delete-pvcs/delete-pvcs.sh
+++ b/cron-jobs/delete-pvcs/delete-pvcs.sh
@@ -1,32 +1,62 @@
 #!/usr/bin/bash
 
-oc login "${HOST}" --token="${TOKEN}"
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
-set -x
+set -eu
+
+# Set TEST=yes to run the script with a mocked oc.
+# See test.sh for test outputs.
+TEST="${TEST:-}"
+
+myoc() {
+    oc -n "${NAMESPACE}" "$@"
+}
+
+if [[ -n "${TEST}" ]]; then
+    source "$(dirname $0)/test.sh"
+fi
 
 DEFAULT_NAMESPACE="packit-${DEPLOYMENT}-sandbox"
 NAMESPACE="${SANDBOX_NAMESPACE:-$DEFAULT_NAMESPACE}"
-POD_NAME_STARTSWITH="quay-io-packit-sandcastle-${DEPLOYMENT}-"
+POD_NAME_PREFIX="quay-io-packit-sandcastle-${DEPLOYMENT}-"
+PVC_NAME_PREFIX="sandcastle--sandcastle"
+JSONPATH="{.spec.volumes[:].persistentVolumeClaim.claimName}"
 
-# get all pods with name starting with POD_NAME_STARTSWITH
-oc get pod -n "${NAMESPACE}" | grep "^${POD_NAME_STARTSWITH}" |
-# for each pod
+myoc login "${HOST}" --token="${TOKEN}"
+
+# ============================================================================
+# Delete Completed and OOMKilled sandbox pods older than a day.
+# ============================================================================
+echo "Checking pods..."
+mounted_pvcs=""
 while IFS= read -r line; do
-  pod_status=$(echo "${line}" | awk '{print $3}')
-  if [[ "${pod_status}" == "Completed" || "${pod_status}" == "OOMKilled" ]];
-  then
+    [[ -z "${line}" ]] && continue
     pod_name=$(echo "${line}" | awk '{print $1}')
+    pod_status=$(echo "${line}" | awk '{print $3}')
     pod_age=$(echo "${line}" | awk '{print $5}')
 
-    # get associated PVC name
-    pvc_name=$(oc get pod "${pod_name}" -n "${NAMESPACE}" -o=jsonpath="{.spec.volumes[0].persistentVolumeClaim.claimName}")
-    echo "Deleting pvc ${pvc_name}"
-    oc delete pvc "${pvc_name}" -n "${NAMESPACE}"
-
-    if [[ "${pod_age: -1}" == "d" ]]; # days
+    if [[ "${pod_status}" == "Completed" || "${pod_status}" == "OOMKilled" ]] \
+        && [[ "${pod_age: -1}" == "d" ]]; # days
     then
-      echo "Deleting pod ${pod_name}"
-      oc delete pod "${pod_name}" -n "${NAMESPACE}"
+        echo "Deleting pod ${pod_name}"
+        myoc delete --ignore-not-found pod "${pod_name}"
+    else
+        # Get associated PVC name.
+        # Multiple values are separated by space.
+        mounted_pvcs="${mounted_pvcs} $(myoc get pod "${pod_name}" -o=jsonpath=${JSONPATH})"
     fi
-  fi
-done
+done <<<$(myoc get pod | grep "^${POD_NAME_PREFIX}")
+# Use awk to filter out empty lines. Grep would exit non-zero if mounted_pvcs is empty.
+mounted_pvcs=$(echo "${mounted_pvcs}" | tr ' ' '\n' | awk '/./ {print $0}')
+
+# ============================================================================
+# Delete the sandbox PVCs which are not mounted in any pod.
+# ============================================================================
+echo "Checking PVCs..."
+all_pvcs=$(myoc get pvc | awk '$0 !~ "NAME" {print $1}')
+while IFS= read -r pvc; do
+    [[ -z "${pvc}" ]] && continue
+    echo "Deleting pvc ${pvc}"
+    myoc delete --ignore-not-found pvc "${pvc}"
+done <<<$(echo -e "${mounted_pvcs}\n${all_pvcs}" | grep "^${PVC_NAME_PREFIX}" | sort | uniq -u)

--- a/cron-jobs/delete-pvcs/test.sh
+++ b/cron-jobs/delete-pvcs/test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+# This redefines myoc() to be more like a mock for the real
+# commands, and return some output resembling the real one.
+
+HOST=example.com
+TOKEN=very-secret-token
+DEPLOYMENT=test
+
+# Using this myoc should result in the script deleting
+# - 2 pods, and
+# - 2 PVCs
+myoc() {
+    if [[ "$1" == "login" || "$1" == "delete" ]]; then
+        echo "oc $@"
+    elif [[ "$1 $2" == "get pod" && $# -eq 2 ]]; then
+        cat << EOF
+NAME                                                   READY     STATUS      RESTARTS   AGE
+delete-pvcs-1628060400-qv4mn                           0/1       Completed   0          31m
+quay-io-packit-sandcastle-${DEPLOYMENT}-del1           0/1       OOMKilled   1          1d
+quay-io-packit-sandcastle-${DEPLOYMENT}-del2           0/1       Completed   0          13d
+quay-io-packit-sandcastle-${DEPLOYMENT}-keep1          0/1       Completed   0          12h
+quay-io-packit-sandcastle-${DEPLOYMENT}-keep2          1/1       Running     0          7m
+EOF
+    elif [[ "$1 $2" == "get pod" && $# -gt 2 ]]; then
+        case "$3" in
+            # PVCs which show up as mounted but then don't show up in the list of PVCs are
+            # deleted.
+            *-keep1)    echo -n "sandcastle-repository-cache sandcastle--sandcastle-pvc-del1";;
+            *-keep2)    echo -n "sandcastle--sandcastle-pvc-keep2 sandcastle-repository-cache";;
+            *)          echo "$3 is not a known scenario"; exit 20;;
+        esac
+    elif [[ "$1 $2" == "get pvc" ]]; then
+        cat << EOF
+NAME                              STATUS    VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS    AGE
+sandcastle-repository-cache       Bound     pvc-038e1c39-f35b-11eb-b815-068b91999b6e   16Gi       RWO            gp2-encrypted   2d
+some-other-pvc-to-keep            Bound     pvc-038e1c39-f35b-11eb-b815-068b91999b6e   16Gi       RWO            gp2-encrypted   2d
+sandcastle--sandcastle-pvc-keep2  Bound     pvc-038e1c38-f35b-11eb-b815-068b91999b6e    2Gi       RWO            gp2-encrypted   2d
+sandcastle--sandcastle-pvc-del2   Bound     pvc-038e1c38-f35b-11eb-b815-068b91999b6e    2Gi       RWO            gp2-encrypted   2d
+EOF
+    else
+        echo "No such oc call in the script: $@"
+        exit 21
+    fi
+}


### PR DESCRIPTION
The previous approach checked for stale pods first and deleted the
corresponding PVCs. But as we found out in the meantime, sometimes pods
are successfully removed, but the PVCs requested by them are not. These
PVCs would be never considered for deletion.

Change the approach to first delete stale pods, then identify all the
sandbox PVCs that are mounted in non-stale pods and then delete any
sandbox PVC that is not mounted.

Set up some basic testing.

Resolves #230.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>