### PR TITLE
base: set locale to C.UTF-8

### DIFF
--- a/containers/Dockerfile.base
+++ b/containers/Dockerfile.base
@@ -3,7 +3,21 @@
 
 FROM fedora:33
 
-ENV LANG=en_US.UTF-8 \
+# do NOT change the locale unless you verify first it is available in the container image:
+#   >>> import locale
+#   >>> locale.setlocale(locale.LC_ALL, "")
+#   'C.UTF-8'
+#   >>> locale.setlocale(locale.LC_ALL, "C")
+#   'C'
+#   >>> locale.setlocale(locale.LC_ALL, "C.UTF-8")
+#   'C.UTF-8'
+#   >>> locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
+#   Traceback (most recent call last):
+#     File "<stdin>", line 1, in <module>
+#     File "/usr/lib64/python3.9/locale.py", line 610, in setlocale
+#       return _setlocale(category, locale)
+#   locale.Error: unsupported locale setting
+ENV LANG=C.UTF-8 \
     ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug
 


### PR DESCRIPTION
because en_US locale is not actually available in the container base
image

    >>> locale.setlocale(locale.LC_ALL, "C.UTF-8")
    'C.UTF-8'
    >>> locale.setlocale(locale.LC_ALL, "en_US.UTF-8")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib64/python3.9/locale.py", line 610, in setlocale
        return _setlocale(category, locale)
    locale.Error: unsupported locale setting

related: https://github.com/rebase-helper/rebase-helper/issues/867