### PR TITLE
Don't set LANG in the base container

### DIFF
--- a/containers/Dockerfile.base
+++ b/containers/Dockerfile.base
@@ -3,8 +3,7 @@
 
 FROM fedora:33
 
-ENV LANG=en_US.UTF-8 \
-    ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
+ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug
 
 RUN dnf update -y && \


### PR DESCRIPTION
Setting this interferes with locale, and breaks working with locales
when it's set to a value for which the locale is not installed (not
present in the output of 'locale -a'), which is the case in Fedora Linux
containers, which have no langpacks installed.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>