### PR TITLE
Bump base image FROM fedora:33 -> 34

### DIFF
--- a/containers/Dockerfile.base
+++ b/containers/Dockerfile.base
@@ -1,7 +1,7 @@
 # Be aware that this image is used for all stages, so if a dependency is removed be sure that it is
 # not required in anywhere
 
-FROM fedora:33
+FROM fedora:34
 
 ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug


### PR DESCRIPTION
Merge this after moving stable branches, i.e. either

- on Friday, so that the [base-image-rebuild workflow](https://github.com/packit/deployment/blob/main/.github/workflows/base-image-rebuild.yml) rebuilds it at 00:00 on Monday
- on Monday and re-run [the latest build](https://github.com/packit/deployment/actions/workflows/base-image-rebuild.yml) manually

after that, rebuild all `stg` images so that we have enough time to test before moving stable branches again.