### PR TITLE
Use repo cache only in workers serving long-running queue

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -47,7 +47,7 @@ spec:
         resources:
           requests:
             storage: 2Gi
-{% if with_repository_cache %}
+{% if with_repository_cache and 'long-running' in queues %}
     - metadata:
         name: packit-worker-repository-cache
       spec:
@@ -147,7 +147,7 @@ spec:
               mountPath: /home/packit/.config
             - name: packit-worker-vol
               mountPath: /sandcastle
-{% if with_repository_cache %}
+{% if with_repository_cache and 'long-running' in queues %}
             - name: packit-worker-repository-cache
               mountPath: /repository-cache
 {% endif %}

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -203,18 +203,6 @@
         - packit-worker
       when: workers_all_tasks > 0
 
-    - name: Deploy repository cache PVCs for packit-workers that serves short-running queue
-      vars:
-        name: "packit-worker-short-running-{{ item }}"
-      k8s:
-        namespace: "{{ sandbox_namespace }}"
-        definition: "{{ lookup('template', '{{ project_dir }}/openshift/sandcastle-volumes-for-cache.yml.j2') }}"
-        host: "{{ host }}"
-        api_key: "{{ api_key }}"
-        validate_certs: "{{ validate_certs }}"
-      loop: "{{ range(0, workers_short_running)|list }}"
-      when: workers_short_running > 0 and with_repository_cache
-
     - name: Deploy packit-worker to serve short-running queue
       vars:
         name: packit-worker-short-running


### PR DESCRIPTION
Related to packit/packit-service#1184

(Don't merge and deploy until the tasks are reorganized)