### PR TITLE
Reschedule to import new images on Tuesday in Prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ More info [here](./cron-jobs/README.md).
 It runs (i.e. imports newer images and re-deploys them)
 
 - STG: Once every hour (at minute 0)
-- PROD: At 2AM on Monday
+- PROD: At 2AM on Tuesday
 
 [2] automatic, [example](https://github.com/packit-service/deployment/blob/main/openshift/deployment.yml.j2#L98)
 

--- a/cron-jobs/import-images/job-import-images.yaml
+++ b/cron-jobs/import-images/job-import-images.yaml
@@ -6,8 +6,8 @@ spec:
   # https://crontab.guru
   # STG: Once every hour (at minute 0)
   schedule: "0 * * * *"
-  # PROD: At 02:00 on Monday
-  # schedule: "0 2 * * 1"
+  # PROD: At 02:00 on Tuesday
+  # schedule: "0 2 * * 2"
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
We discussed on retro to move the stable branches on Monday, instead of
Friday, and release a new version of the service on Tuesday. This way if
something goes wrong we can take care of it during the week, without
ruining someones weekend.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>