### PR TITLE
Make the memory limits of service-workers configurable

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -1,24 +1,6 @@
-# MIT License
-#
-# Copyright (c) 2018-2019 Red Hat, Inc.
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
 ---
 # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset
 kind: StatefulSet
@@ -155,9 +137,7 @@ spec:
             - "/usr/bin/run_worker.sh"
           resources:
             limits:
-              # cloning repos is memory intensive: glibc needs 300M+, kernel 600M+
-              # during cloning, we need to account for git and celery worker processes
-              memory: "896Mi"
+              memory: {{ worker_memory }}
               cpu: "400m"
           # https://github.com/packit/deployment/pull/142
           #readinessProbe:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -194,6 +194,9 @@
         name: packit-worker
         queues: "short-running,long-running"
         worker_replicas: "{{ workers_all_tasks }}"
+        # cloning repos is memory intensive: glibc needs 300M+, kernel 600M+
+        # during cloning, we need to account for git and celery worker processes
+        worker_memory: 896Mi
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"
@@ -209,6 +212,9 @@
         name: packit-worker-short-running
         queues: "short-running"
         worker_replicas: "{{ workers_short_running }}"
+        # Short-running tasks are just ineractions with different services.
+        # They should not require a lot of memory.
+        worker_memory: 128Mi
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"
@@ -236,6 +242,9 @@
         name: packit-worker-long-running
         queues: "long-running"
         worker_replicas: "{{ workers_long_running }}"
+        # cloning repos is memory intensive: glibc needs 300M+, kernel 600M+
+        # during cloning, we need to account for git and celery worker processes
+        worker_memory: 896Mi
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"


### PR DESCRIPTION
Workers processing queues with short-running tasks require much less
memory than those which also process long-running tasks.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>