### PR TITLE
Configure deploying a long-running worker in prod

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -187,6 +187,8 @@
         api_key: "{{ api_key }}"
         validate_certs: "{{ validate_certs }}"
       loop: "{{ range(0, workers_all_tasks)|list }}"
+      tags:
+        - packit-worker
       when: workers_all_tasks > 0 and with_repository_cache
 
     - name: Deploy packit-worker to serve both queues
@@ -235,6 +237,8 @@
         api_key: "{{ api_key }}"
         validate_certs: "{{ validate_certs }}"
       loop: "{{ range(0, workers_long_running)|list }}"
+      tags:
+        - packit-worker
       when: workers_long_running > 0 and with_repository_cache
 
     - name: Deploy packit-worker to serve long-running queue

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -216,7 +216,7 @@
         worker_replicas: "{{ workers_short_running }}"
         # Short-running tasks are just ineractions with different services.
         # They should not require a lot of memory.
-        worker_memory: 128Mi
+        worker_memory: 256Mi
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -74,4 +74,4 @@ repository_cache_storage: 10Gi
 # Number of worker pods to be deployed to serve the queues
 # workers_all_tasks: 1
 workers_short_running: 1
-# workers_long_running: 0
+workers_long_running: 1


### PR DESCRIPTION
Jobs on some Cockpit repositories max out their time when building
SRPMs. This makes other repositories to wait longer for their SRPM
builds. Add a new worker to serve long-running tasks to improve on this
situation.