### PR TITLE
validation: use pr.comment instead of project.pr_comment

### DIFF
--- a/cron-jobs/packit-service-validation/packit-service-validation.py
+++ b/cron-jobs/packit-service-validation/packit-service-validation.py
@@ -70,7 +70,7 @@ class Testcase:
         :return:
         """
         if self.trigger == Trigger.comment:
-            project.pr_comment(self.pr.id, "/packit build")
+            self.pr.comment("/packit build")
         elif self.trigger == Trigger.push:
             self.push_to_pr()
         else:


### PR DESCRIPTION
this was deprecated and removed from ogr already

Fixes https://sentry.io/organizations/red-hat-0p/issues/2793426268

Tests still running locally for me.