### PR TITLE
Pass PROJECT into worker

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -60,6 +60,8 @@ spec:
         - name: packit-worker-1
           image: packit-worker:{{ deployment }}
           env:
+            - name: PROJECT
+              value: {{ project }}
             - name: DEPLOYMENT
               value: {{ deployment }}
             - name: DISTGIT_URL


### PR DESCRIPTION
~`SERVICE` is really a bad name for this variable.
I chose it to distinguish between 'packit service' and 'stream service', but 'service' has so many meanings.
We are in a deployment repo and the variable basically specifies which project to deploy to - so `PROJECT` is much better.
It's used when playbooks are created from Jinja templates, so nothing needs to be re-deployed or changed anywhere else.~

EDIT: No renaming, see comments below. This PR just passes `project` (ansible) variable to worker as `PROJECT` to be utilized [here](https://github.com/packit/packit-service/blob/17e56e0fa9121aeca44afd27cf1dba973c0b21b5/packit_service/worker/database.py#L122).

---

N/A