### PR TITLE
Check that the deployment resources are up to date

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,3 +3,5 @@
 skip_list:
   - yaml  # clashes with prettier
   - role-name  # we're not going to publish the roles
+warn_list:
+  - command-instead-of-module  # sometimes this is desired

--- a/README.md
+++ b/README.md
@@ -2,10 +2,25 @@
 
 ## tl;dr How to deploy
 
-1. Obtain all the necessary [secrets](/secrets/README.md).
-2. Create a deployment config from a template as described in [vars/README](vars/README.md).
+1. Obtain all the necessary [secrets](secrets/README.md).
+2. Configure the deployment by creating a variable file in 'vars/' from a
+   template as described in [vars/README](vars/README.md).
 3. `dnf install ansible origin-clients python3-openshift`
-4. `[SERVICE={service}] DEPLOYMENT={deployment} make deploy` (see [vars/README](vars/README.md)).
+4. `[SERVICE={service}] DEPLOYMENT={deployment} make deploy` (see
+   [vars/README](vars/README.md)).
+
+By default, the playbook checks that the local copies of the deployment and
+secrets repositories are up to date, and the variable file used is up to
+date with the corresponding template.
+
+For these checks to work, you need to set `secrets_repo_url` in the variable
+file used.
+
+To disable all these check, set `check_up_to_date` to `false` in the
+variable file.
+
+To only disable comparing the variable file to the template, set
+`check_vars_template_diff` to `false`.
 
 ## What's in here
 

--- a/playbooks/check.yml
+++ b/playbooks/check.yml
@@ -13,9 +13,9 @@
     - name: include variables
       include_vars: "{{ project_dir }}/vars/{{ service }}/{{ deployment }}.yml"
 
-    - name: Getting DCs
+    - name: Getting deploymentconfigs
       include_tasks: tasks/set-facts.yml
 
-    - name: Checking running pods of {{ DCs }}
+    - name: Checking running pods of {{ deploymentconfigs }}
       include_tasks: tasks/check-pod-running.yml
-      loop: "{{ DCs + ['packit-worker'] }}"
+      loop: "{{ deploymentconfigs + ['packit-worker'] }}"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -43,6 +43,13 @@
     distgit_url: https://src.fedoraproject.org/
     distgit_namespace: rpms
     pushgateway_address: http://pushgateway
+    # Check that the deployment resources are up to date
+    check_up_to_date: true
+    # Check that the current vars file us up to date with the template
+    check_vars_template_diff: true
+    deployment_repo_url: https://github.com/packit/deployment.git
+    # Needs to be defined in vars/
+    secrets_repo_url: ""
   tasks:
     - include_tasks: tasks/project-dir.yml
       tags:
@@ -53,7 +60,11 @@
       tags:
         - always
 
-    - name: Getting DCs
+    - include_tasks: tasks/check-up-to-date.yml
+      tags:
+        - always
+
+    - name: Getting deploymentconfigs
       include_tasks: tasks/set-facts.yml
       tags:
         - always
@@ -435,13 +446,13 @@
         wait_timeout: 600 # 10 minutes to pull the image and run the container
       when: workers_long_running > 0
 
-    - name: Wait for DCs rollouts to complete
+    - name: Wait for deploymentconfig rollouts to complete
       # timeout 10min to not wait indefinitely in case of a problem
       command: timeout 10m oc rollout status -w dc/{{ item }}
       register: oc_rollout_status
       changed_when: false
       failed_when: '"successfully rolled out" not in oc_rollout_status.stdout'
-      loop: "{{ DCs }}"
+      loop: "{{ deploymentconfigs }}"
 
   handlers:
     - name: Rollout redis-commander

--- a/playbooks/tasks/check-up-to-date.yml
+++ b/playbooks/tasks/check-up-to-date.yml
@@ -1,0 +1,66 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+---
+- name: Check that the deployment resources are up to date
+  when: zuul is not defined and check_up_to_date
+  block:
+    - name: Get HEAD from the remote
+      ansible.builtin.command:
+        chdir: "{{ project_dir }}"
+        cmd: "git ls-remote {{ deployment_repo_url }} main"
+      register: remote_head
+      changed_when: remote_head.rc != 0
+      failed_when: remote_head.rc != 0
+    - name: Get local HEAD
+      ansible.builtin.command:
+        chdir: "{{ project_dir }}"
+        cmd: git show-ref -s refs/heads/main
+      register: local_head
+      changed_when: local_head.rc != 0
+      failed_when: local_head.rc != 0
+    - name: Compare deployment repo hashes
+      ansible.builtin.assert:
+        that:
+          - remote_head.stdout.split()[0] == local_head.stdout
+        fail_msg: "The main branch of the deployment repo is not up to date"
+    - name: Check HEAD from secrets remote
+      ansible.builtin.command:
+        chdir: "{{ path_to_secrets }}"
+        cmd: "git ls-remote {{ secrets_repo_url }} master"
+      register: remote_secrets_head
+      changed_when: remote_secrets_head.rc != 0
+      failed_when: remote_secrets_head.rc != 0
+    - name: Check HEAD from local secrets
+      ansible.builtin.command:
+        chdir: "{{ path_to_secrets }}"
+        cmd: git show-ref -s refs/heads/master
+      register: local_secrets_head
+      changed_when: local_secrets_head.rc != 0
+      failed_when: local_secrets_head.rc != 0
+    - name: Compare secrets repo hashes
+      ansible.builtin.assert:
+        that:
+          - remote_secrets_head.stdout.split()[0] == local_secrets_head.stdout
+        fail_msg: "The master branch of the secrets repo is not up to date"
+    - name: Calculate the diff of the current vars file
+      when: check_vars_template_diff
+      ansible.builtin.shell:
+        chdir: "{{ project_dir }}"
+        # Remove the keys expected to be different and lines specific to the diff-format.
+        cmd: >-
+          diff vars/{{ service }}/{{ deployment }}.yml vars/{{ service }}/{{ deployment }}_template.yml |
+          sed '/api_key/d;/secrets_repo_url/d;/[0-9]\+c[0-9]\+/d;/---/d'
+      register: diff
+      changed_when: diff.rc != 0
+      failed_when: diff.rc != 0
+    - name: Check that there are no unexpected lines in the diff
+      when: check_vars_template_diff
+      ansible.builtin.assert:
+        that:
+          - not diff.stdout
+        fail_msg: >-
+          The diff between
+          'vars/{{ service }}/{{ deployment }}.yml' and
+          'vars/{{ service }}/{{ deployment }}_template.yml' is has some
+          unexpected lines: {{ diff.stdout }}

--- a/playbooks/tasks/set-facts.yml
+++ b/playbooks/tasks/set-facts.yml
@@ -2,17 +2,17 @@
 # SPDX-License-Identifier: MIT
 
 ---
-- name: Set mandatory_DCs fact
+- name: Set mandatory_deploymentconfigs fact
   set_fact:
-    mandatory_DCs:
+    mandatory_deploymentconfigs:
       - postgres-13
       - redis
       - packit-service
   tags:
     - always
-- name: Set optional_DCs fact
+- name: Set optional_deploymentconfigs fact
   set_fact:
-    optional_DCs:
+    optional_deploymentconfigs:
       tokman: "{{ with_tokman }}"
       packit-service-fedmsg: "{{ with_fedmsg }}"
       packit-service-beat: "{{ with_beat }}"
@@ -21,9 +21,9 @@
       nginx: "{{ with_pushgateway }}"
   tags:
     - always
-- name: Set DCs fact
+- name: Set deploymentconfigs fact
   set_fact:
     # To know what DCs rollouts to wait for and also to check in tests
-    DCs: '{{ mandatory_DCs + optional_DCs|dict2items|selectattr("value", "equalto", true)|list|map(attribute="key")|flatten }}'
+    deploymentconfigs: '{{ mandatory_deploymentconfigs + optional_deploymentconfigs|dict2items|selectattr("value", "equalto", true)|list|map(attribute="key")|flatten }}'
   tags:
     - always

--- a/playbooks/zuul-deploy.yml
+++ b/playbooks/zuul-deploy.yml
@@ -36,6 +36,7 @@
           host: https://127.0.0.1:8443
           api_key: {{ kubeconfig_token.stdout }}
           validate_certs: false
+          check_up_to_date: false
           # Whether to deploy and check that pod
           with_tokman: true
           with_beat: true

--- a/vars/packit/dev_template.yml
+++ b/vars/packit/dev_template.yml
@@ -18,6 +18,15 @@ api_key: ""
 # To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
 validate_certs: false
 
+# Don't check that the deployment resources are up to date
+check_up_to_date: false
+
+# Check that the current vars file us up to date with the template
+# check_vars_template_diff: true
+
+# Git URL ("Clone with SSH") of the repository where secrets are stored
+# secrets_repo_url: ""
+
 # with_tokman: true
 
 # if you want to deploy fedmsg, please make sure to

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -18,6 +18,15 @@ api_key: ""
 
 # validate_certs: true
 
+# Check that the deployment resources are up to date
+# check_up_to_date: true
+
+# Check that the current vars file us up to date with the template
+# check_vars_template_diff: true
+
+# Git URL ("Clone with SSH") of the repository where secrets are stored
+secrets_repo_url: ""
+
 # with_tokman: true
 
 # if you want to deploy fedmsg, please make sure to

--- a/vars/packit/stg_template.yml
+++ b/vars/packit/stg_template.yml
@@ -17,6 +17,15 @@ host: https://api.test-cluster.pxso.p1.openshiftapps.com:6443
 api_key: ""
 # validate_certs: true
 
+# Check that the deployment resources are up to date
+# check_up_to_date: true
+
+# Check that the current vars file us up to date with the template
+# check_vars_template_diff: true
+
+# Git URL ("Clone with SSH") of the repository where secrets are stored
+secrets_repo_url: ""
+
 # with_tokman: true
 
 # if you want to deploy fedmsg, please make sure to

--- a/vars/stream/dev_template.yml
+++ b/vars/stream/dev_template.yml
@@ -18,6 +18,15 @@ api_key: ""
 # To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
 validate_certs: false
 
+# Don't check that the deployment resources are up to date
+check_up_to_date: false
+
+# Check that the current vars file us up to date with the template
+# check_vars_template_diff: true
+
+# Git URL ("Clone with SSH") of the repository where secrets are stored
+# secrets_repo_url: ""
+
 with_tokman: false
 
 with_fedmsg: false

--- a/vars/stream/prod_template.yml
+++ b/vars/stream/prod_template.yml
@@ -18,6 +18,15 @@ api_key: ""
 
 # validate_certs: true
 
+# Check that the deployment resources are up to date
+# check_up_to_date: true
+
+# Check that the current vars file us up to date with the template
+# check_vars_template_diff: true
+
+# Git URL ("Clone with SSH") of the repository where secrets are stored
+secrets_repo_url: ""
+
 with_tokman: false
 
 with_fedmsg: false

--- a/vars/stream/stg_template.yml
+++ b/vars/stream/stg_template.yml
@@ -18,6 +18,15 @@ api_key: ""
 
 # validate_certs: true
 
+# Check that the deployment resources are up to date
+# check_up_to_date: true
+
+# Check that the current vars file us up to date with the template
+# check_vars_template_diff: true
+
+# Git URL ("Clone with SSH") of the repository where secrets are stored
+secrets_repo_url: ""
+
 with_tokman: false
 
 with_fedmsg: false

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -16,6 +16,14 @@ host: https://your-openshift-cluster-url
 api_key: ""
 # validate_certs: true
 
+# Check that the deployment resources are up to date
+# check_up_to_date: true
+
+# Check that the current vars file us up to date with the template
+# check_vars_template_diff: true
+
+# Git URL ("Clone with SSH") of the repository where secrets are stored
+secrets_repo_url: ""
 # with_tokman: true
 
 # if you want to deploy fedmsg, please make sure to


### PR DESCRIPTION
When running a deployment, first check that:
- the deployment repository is up to date as compared to its remote;
- the secrets repository is up to date as compared to its remote;
- the deployment configuration is up to date compared to its template.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>