### PR TITLE
Use Burstable instead of Guaranteed QoS for workers

### DIFF
--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -78,7 +78,8 @@ spec:
             limits:
               # run_httpd.sh does 'alembic upgrade head' which might require more memory
               # If you see '/usr/bin/run_httpd.sh: line 16:   Killed     alembic upgrade head'
-              # you have to temporarily increase the limit (last time 512M was enough),
+              # you have to temporarily increase (in webUI/console) the limit
+              # (2Gi@prod, 512Mi@stg was enough last time),
               # and once the alembic upgrade passes, revert.
               memory: "196Mi"
               cpu: "200m"

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -129,13 +129,12 @@ spec:
           command:
             - "/usr/bin/run_worker.sh"
           resources:
-            # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: {{ worker_memory }}
-              cpu: {{ worker_cpu }}
+              memory: {{ worker_requests_memory }}
+              cpu: {{ worker_requests_cpu }}
             limits:
-              memory: {{ worker_memory }}
-              cpu: {{ worker_cpu }}
+              memory: {{ worker_limits_memory }}
+              cpu: {{ worker_limits_cpu }}
           # https://github.com/packit/deployment/pull/142
           #readinessProbe:
           #  exec:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -207,8 +207,10 @@
         worker_replicas: "{{ workers_all_tasks }}"
         # cloning repos is memory intensive: glibc needs 300M+, kernel 600M+
         # during cloning, we need to account for git and celery worker processes
-        worker_memory: "896Mi"
-        worker_cpu: "400m"
+        worker_requests_memory: "384Mi"
+        worker_requests_cpu: "100m"
+        worker_limits_memory: "1024Mi"
+        worker_limits_cpu: "400m"
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"
@@ -226,8 +228,10 @@
         worker_replicas: "{{ workers_short_running }}"
         # Short-running tasks are just interactions with different services.
         # They should not require a lot of memory/cpu.
-        worker_memory: "320Mi"
-        worker_cpu: "100m"
+        worker_requests_memory: "320Mi"
+        worker_requests_cpu: "100m"
+        worker_limits_memory: "320Mi"
+        worker_limits_cpu: "100m"
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"
@@ -259,8 +263,11 @@
         worker_replicas: "{{ workers_long_running }}"
         # cloning repos is memory intensive: glibc needs 300M+, kernel 600M+
         # during cloning, we need to account for git and celery worker processes
-        worker_memory: "896Mi"
-        worker_cpu: "400m"
+        worker_requests_memory: "384Mi"
+        worker_requests_cpu: "100m"
+        worker_limits_memory: "1024Mi"
+        worker_limits_cpu: "400m"
+
       k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -79,5 +79,5 @@ repository_cache_storage: 10Gi
 # Number of worker pods to be deployed to serve the queues
 # workers_all_tasks: 1
 workers_short_running: 1
-workers_long_running: 1
+workers_long_running: 2
 # pushgateway_address: http://pushgateway


### PR DESCRIPTION
Since 9f1186bed all pods have had [Guaranteed Quality of Service (QoS)](https://medium.com/google-cloud/quality-of-service-class-qos-in-kubernetes-bb76a89eb2c6).
But for workers (long-running and all-tasks) Burstable QoS is more appropriate because:
- most of the time they don't need so many resources, but under pressure, they need 2-4x more
- we would survive even if the system (k8s/Openshift) started killing them in case of running out of memory (unlikely to happen, but still)

EDIT: I was also thinking about doing the same for `packit-service` DeploymentConfig and increasing its memory limit to 2Gi, because that's the value we needed last time when doing alembic migrations.
It can be done because we don't have any quota now and we wouldn't need to increase it manually next (each) time we do an alembic migration.
On the other hand, it moves the packit-service pod from Guaranteed to Burstable QoS, which means a higher probability of being killed if the node runs out of memory.
Not sure how likely that is, but given that there are AFAICT no quotas per project, it can IMO happen.
To stay on the safe side, I decided to leave it as it is now.
