### PR TITLE
changelog script improvements

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -19,6 +19,16 @@ def get_relevant_commits(repository: Repo, ref: str) -> List[Commit]:
     return list(repository.iter_commits(rev=range, merges=True))
 
 
+def get_pr_data(message: str) -> str:
+    """
+    obtain PR ID and produce a markdown link to it
+    """
+    # Merge pull request #1483 from majamassarini/fix/1357
+    first_line = message.split("\n")[0]
+    fourth_word = first_line.split(" ")[3]
+    return fourth_word
+
+
 def convert_message(message: str) -> Optional[str]:
     """ Extract release note from the commit message,
     return None if there is no release note"""
@@ -43,7 +53,8 @@ def get_changelog(commits: List[Commit]) -> str:
     for commit in commits:
         message = convert_message(commit.message)
         if messsage and message.lower() not in NOT_IMPORTANT_VALUES:
-            changelog += f"- {message}\n"
+            suffix = get_pr_data(commit.message)
+            changelog += f"- {message} ({suffix})\n"
     return changelog
 
 

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -3,12 +3,15 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-from typing import List
+import re
+from typing import List, Optional
 
 import click
 from git import Commit, Repo
 
-NOT_IMPORTANT_VALUES = ["n/a", "none", "none."]
+NOT_IMPORTANT_VALUES = ["n/a", "none", "none.", ""]
+RELEASE_NOTES_TAG = "RELEASE NOTES"
+RELEASE_NOTES_RE = f"{RELEASE_NOTES_TAG} BEGIN(.+){RELEASE_NOTES_TAG} END"
 
 
 def get_relevant_commits(repository: Repo, ref: str) -> List[Commit]:
@@ -16,16 +19,30 @@ def get_relevant_commits(repository: Repo, ref: str) -> List[Commit]:
     return list(repository.iter_commits(rev=range, merges=True))
 
 
-def convert_message(message: str) -> str:
-    cleared_message = message.split("Reviewed-by")[0].strip()
-    return cleared_message.split("\n\n")[-1].strip()
+def convert_message(message: str) -> Optional[str]:
+    """ Extract release note from the commit message,
+    return None if there is no release note"""
+    if RELEASE_NOTES_TAG in message:
+        # new
+        if match := re.findall(RELEASE_NOTES_RE, message):
+            return match[0]
+        else:
+            return None
+    else:
+        # old
+        cleared_message = message.split("Reviewed-by")[0].strip()
+        release_note = cleared_message.split("\n\n")[-1].strip()
+        if "Signed-off-by" in release_note:
+            # empty release note
+            return None
+        return release_note
 
 
 def get_changelog(commits: List[Commit]) -> str:
     changelog = ""
     for commit in commits:
         message = convert_message(commit.message)
-        if message.lower() not in NOT_IMPORTANT_VALUES:
+        if messsage and message.lower() not in NOT_IMPORTANT_VALUES:
             changelog += f"- {message}\n"
     return changelog
 

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -30,7 +30,7 @@ def get_pr_data(message: str) -> str:
 
 
 def convert_message(message: str) -> Optional[str]:
-    """ Extract release note from the commit message,
+    """Extract release note from the commit message,
     return None if there is no release note"""
     if RELEASE_NOTES_TAG in message:
         # new


### PR DESCRIPTION
2 changes:

```
changelog script: suffix items with #PR_ID

to have nice links in a release description
```

```
changelog script: support both release notes formats

v1 is `---`

v2 is the RELEASE NOTES section

this commit adds support for both
```

used to generate https://github.com/packit/packit/pull/1485