### PR TITLE
More improvements to changelog script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,25 @@
+# Updating the changelog
+
+In order to simplify the process of Github releases (mainly in packit and ogr), we generate the changelog semi-automatically. The script `changelog.py` goes through the merge commits starting from the specified ref (typically the tag of the last release) and parses the changelog entry from our PR template.
+
+In order to generate the changelog
+
+1. [OPTIONAL] Add the changelog script to your `PATH` to simplify its usage, e.g. by adding `export PATH="~/repos/deployment/scripts:$PATH"` to your `.bashrc` or `.zshrc`.
+2. Call the script:
+
+```
+# get changes in the current directory since the last release
+$ changelog.py
+
+# specify a ref explicitly
+$ changelog.py 0.34.0
+
+# use a different git-repo
+$ changelog.py --git-repo ~/repos/packit 0.34.0
+
+# refer to the help message for more information
+$ changelog.py --help
+
+```
+
+3. Manually adjust the output and add it to `CHANGELOG.md` with a header.

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -12,6 +12,7 @@ from git import Commit, Repo
 NOT_IMPORTANT_VALUES = ["n/a", "none", "none.", ""]
 RELEASE_NOTES_TAG = "RELEASE NOTES"
 RELEASE_NOTES_RE = f"{RELEASE_NOTES_TAG} BEGIN\n(.+)\n{RELEASE_NOTES_TAG} END"
+PRE_COMMIT_CI_MESSAGE = "pre-commit autoupdate"
 
 
 def get_relevant_commits(repository: Repo, ref: str) -> List[Commit]:
@@ -51,6 +52,8 @@ def convert_message(message: str) -> Optional[str]:
 def get_changelog(commits: List[Commit]) -> str:
     changelog = ""
     for commit in commits:
+        if PRE_COMMIT_CI_MESSAGE in commit.message:
+            continue
         message = convert_message(commit.message)
         if message and message.lower() not in NOT_IMPORTANT_VALUES:
             suffix = get_pr_data(commit.message)

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -52,7 +52,7 @@ def get_changelog(commits: List[Commit]) -> str:
     changelog = ""
     for commit in commits:
         message = convert_message(commit.message)
-        if messsage and message.lower() not in NOT_IMPORTANT_VALUES:
+        if message and message.lower() not in NOT_IMPORTANT_VALUES:
             suffix = get_pr_data(commit.message)
             changelog += f"- {message} ({suffix})\n"
     return changelog

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -11,7 +11,7 @@ from git import Commit, Repo
 
 NOT_IMPORTANT_VALUES = ["n/a", "none", "none.", ""]
 RELEASE_NOTES_TAG = "RELEASE NOTES"
-RELEASE_NOTES_RE = f"{RELEASE_NOTES_TAG} BEGIN(.+){RELEASE_NOTES_TAG} END"
+RELEASE_NOTES_RE = f"{RELEASE_NOTES_TAG} BEGIN\n(.+)\n{RELEASE_NOTES_TAG} END"
 
 
 def get_relevant_commits(repository: Repo, ref: str) -> List[Commit]:
@@ -34,7 +34,7 @@ def convert_message(message: str) -> Optional[str]:
     return None if there is no release note"""
     if RELEASE_NOTES_TAG in message:
         # new
-        if match := re.findall(RELEASE_NOTES_RE, message):
+        if match := re.findall(RELEASE_NOTES_RE, message, re.DOTALL):
             return match[0]
         else:
             return None


### PR DESCRIPTION
- fix of typo from the previous PR causing a traceback
- better handling of newlines
- ignoring of pre-commit autoupdate messages
- ref no longer needs to be specified, the last tag is used by default
- README describing how to use it