### PR TITLE
Remove -1 suffix from packit-worker container name

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,7 +3,7 @@
     check:
       jobs:
         - pre-commit
-    #        - deployment-tests
+        - deployment-tests
     gate:
       jobs:
         - pre-commit

--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -16,6 +16,9 @@ spec:
       labels:
         service: packit-dashboard
         name: packit-dashboard
+      # https://docs.openshift.com/container-platform/4.9/openshift_images/using-imagestreams-with-kube-resources.html
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       containers:
         - name: packit-dashboard

--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -20,6 +20,7 @@ spec:
       containers:
         - name: packit-dashboard
           image: packit-dashboard:{{ deployment }}
+          imagePullPolicy: Always
           ports:
             - containerPort: 8443
           volumeMounts:

--- a/openshift/flower.yml
+++ b/openshift/flower.yml
@@ -20,6 +20,7 @@ spec:
       containers:
         - name: flower
           image: mher/flower
+          imagePullPolicy: Always
           env:
             - name: CELERY_BROKER_URL
               value: redis://redis:6379/0

--- a/openshift/nginx.yml.j2
+++ b/openshift/nginx.yml.j2
@@ -26,6 +26,7 @@ spec:
       containers:
       - name: nginx
         image: nginxinc/nginx-unprivileged
+        imagePullPolicy: Always
         ports:
         - containerPort: 8443
         volumeMounts:

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -15,6 +15,9 @@ spec:
       labels:
         name: packit-service-beat
         app: packit
+      # https://docs.openshift.com/container-platform/4.9/openshift_images/using-imagestreams-with-kube-resources.html
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       volumes:
         - name: packit-ssh

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -29,6 +29,7 @@ spec:
       containers:
         - name: packit-service-fedmsg
           image: packit-service-fedmsg:{{ deployment }}
+          imagePullPolicy: Always
           env:
             - name: FEDORA_MESSAGING_CONF
               value: /home/packit/.config/fedora.toml

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -15,6 +15,9 @@ spec:
       labels:
         name: packit-service-fedmsg
         app: packit
+      # https://docs.openshift.com/container-platform/4.9/openshift_images/using-imagestreams-with-kube-resources.html
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       volumes:
         - name: packit-ssh

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -15,6 +15,9 @@ spec:
       labels:
         name: packit-service
         app: packit
+      # https://docs.openshift.com/container-platform/4.9/openshift_images/using-imagestreams-with-kube-resources.html
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       volumes:
         - name: packit-secrets

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -26,6 +26,7 @@ spec:
       containers:
         - name: packit-service
           image: packit-service:{{ deployment }}
+          imagePullPolicy: Always
           ports:
             - containerPort: 8443
               protocol: TCP

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -41,7 +41,7 @@ spec:
       labels:
         name: {{ name }}
         app: packit
-      # https://docs.openshift.com/container-platform/3.11/dev_guide/managing_images.html#using-is-with-k8s
+      # https://docs.openshift.com/container-platform/4.9/openshift_images/using-imagestreams-with-kube-resources.html
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'
     spec:

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -10,9 +10,9 @@ metadata:
   annotations:
     # Setting triggers to StatefulSet is tricky (they also don't appear in GUI).
     # I run the following and then checked how the resulting yaml looks like.
-    # oc set triggers statefulset.apps/packit-worker --from-image=packit-worker:dev -c packit-worker-1
+    # oc set triggers statefulset.apps/packit-worker --from-image=packit-worker:dev -c packit-worker
     image.openshift.io/triggers: >-
-      [{"from":{"kind":"ImageStreamTag","name":"packit-worker:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"packit-worker-1\")].image"}]
+      [{"from":{"kind":"ImageStreamTag","name":"packit-worker:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"packit-worker\")].image"}]
 spec:
   selector:
     matchLabels:
@@ -57,7 +57,7 @@ spec:
           secret:
             secretName: packit-config
       containers:
-        - name: packit-worker-1
+        - name: packit-worker
           image: packit-worker:{{ deployment }}
           env:
             - name: PROJECT

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -21,7 +21,10 @@ spec:
         name: postgres-13
     spec:
       containers:
-        - env:
+        - name: postgres
+          image: quay.io/centos7/postgresql-13-centos7
+          imagePullPolicy: Always
+          env:
             - name: POSTGRESQL_USER
               valueFrom:
                 secretKeyRef:
@@ -40,9 +43,6 @@ spec:
             # https://www.postgresql.org/docs/13/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT
             - name: PG_OOM_ADJUST_FILE
               value: "/proc/self/oom_score_adj"
-          image: quay.io/centos7/postgresql-13-centos7
-          imagePullPolicy: IfNotPresent
-          name: postgres
           ports:
             - containerPort: 5432
               protocol: TCP

--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -18,9 +18,9 @@ spec:
       containers:
         - name: pushgateway
           image: weaveworks/prom-aggregation-gateway
+          imagePullPolicy: Always
           args:
             - "--listen=:9091"
-          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9091
           resources:

--- a/openshift/redis-commander.yml
+++ b/openshift/redis-commander.yml
@@ -20,6 +20,7 @@ spec:
       containers:
         - name: redis-commander
           image: rediscommander/redis-commander
+          imagePullPolicy: Always
           env:
             - name: REDIS_HOST
               value: redis

--- a/openshift/redis.yml
+++ b/openshift/redis.yml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: redis
           image: quay.io/centos7/redis-5-centos7
+          imagePullPolicy: Always
           ports:
             - containerPort: 6379
           volumeMounts:

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -29,6 +29,7 @@ spec:
       containers:
         - name: tokman
           image: tokman:{{ deployment }}
+          imagePullPolicy: Always
           env:
             - name: DEPLOYMENT
               value: {{ deployment }}

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -15,6 +15,9 @@ spec:
       labels:
         name: tokman
         app: packit
+      # https://docs.openshift.com/container-platform/4.9/openshift_images/using-imagestreams-with-kube-resources.html
+      annotations:
+        alpha.image.policy.openshift.io/resolve-names: '*'
     spec:
       volumes:
         - name: github-app-private-key

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -411,6 +411,14 @@
         - pushgateway
       when: with_pushgateway
 
+    - name: Wait for deploymentconfig rollouts to complete
+      # timeout 10min to not wait indefinitely in case of a problem
+      command: timeout 10m oc rollout status -w dc/{{ item }}
+      register: oc_rollout_status
+      changed_when: false
+      failed_when: '"successfully rolled out" not in oc_rollout_status.stdout'
+      loop: "{{ deploymentconfigs }}"
+
     - name: Wait for worker-0 to be running
       k8s:
         namespace: "{{ project }}"
@@ -452,14 +460,6 @@
           type: Ready
         wait_timeout: 600 # 10 minutes to pull the image and run the container
       when: workers_long_running > 0
-
-    - name: Wait for deploymentconfig rollouts to complete
-      # timeout 10min to not wait indefinitely in case of a problem
-      command: timeout 10m oc rollout status -w dc/{{ item }}
-      register: oc_rollout_status
-      changed_when: false
-      failed_when: '"successfully rolled out" not in oc_rollout_status.stdout'
-      loop: "{{ deploymentconfigs }}"
 
   handlers:
     - name: Rollout redis-commander


### PR DESCRIPTION
From what I can see in history it's been always like that.
But it's confusing since the pod names are also numbered, so we have a pod named `packit-worker-0`, which has a container named `packit-worker-1`.

For the other commits see #310