### PR TITLE
Have 2 workers handle short running tasks

### DIFF
--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -78,6 +78,6 @@ repository_cache_storage: 10Gi
 
 # Number of worker pods to be deployed to serve the queues
 # workers_all_tasks: 1
-workers_short_running: 1
+workers_short_running: 2
 workers_long_running: 2
 # pushgateway_address: http://pushgateway


### PR DESCRIPTION
When the number of events from GitHub is high, the service is often
failing to give the initial feedback within 15 seconds.

Increase the number of workers handling short running tasks, in an
attempt to shorten response times.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>