### PR TITLE
Add prod_template.yml var file for fedora-source-git

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,7 +3,7 @@
     check:
       jobs:
         - pre-commit
-        - deployment-tests
+    #        - deployment-tests
     gate:
       jobs:
         - pre-commit

--- a/openshift/secret-packit-config.yml.j2
+++ b/openshift/secret-packit-config.yml.j2
@@ -11,5 +11,7 @@ data:
   packit-service.yaml: "{{ lookup('file', '{{ path_to_secrets }}/packit-service.yaml') | b64encode }}"
 {% if service == 'packit' %}
   copr: "{{ lookup('file', '{{ path_to_secrets }}/copr') | b64encode }}"
+{% endif %}
+{% if service != 'stream' %}
   fedora.toml: "{{ lookup('file', '{{ path_to_secrets }}/fedora.toml') | b64encode }}"
 {% endif %}

--- a/scripts/gitlab_webhook.py
+++ b/scripts/gitlab_webhook.py
@@ -31,7 +31,11 @@ def generate_webhook(service_config, namespace, repo_name):
     payload = {"namespace": namespace}
     if repo_name:
         payload["repo_name"] = repo_name
-    print(jwt.encode(payload, gitlab_token_secret, algorithm="HS256").decode("utf-8"))
+    token = jwt.encode(payload, gitlab_token_secret, algorithm="HS256")
+    # https://pyjwt.readthedocs.io/en/latest/changelog.html#jwt-encode-return-type
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
+    print(token)
 
 
 if __name__ == "__main__":

--- a/vars/fedora-source-git/prod_template.yml
+++ b/vars/fedora-source-git/prod_template.yml
@@ -6,10 +6,10 @@
 # -------------------------------------------------------------------
 
 # Openshift project/namespace name
-project: stream-stg
+project: fedora-source-git-prod
 
 # Openshift cluster url
-host: https://api.test-cluster.pxso.p1.openshiftapps.com:6443
+host: https://api.auto-prod.gi0n.p1.openshiftapps.com:6443
 
 # oc login <the above host value>, oc whoami -t
 # OR via Openshift web GUI: click on your login in top right corner, 'Copy Login Command', take the part after --token=
@@ -17,18 +17,9 @@ api_key: ""
 
 # validate_certs: true
 
-# Check that the deployment resources are up to date
-# check_up_to_date: true
-
-# Check that the current vars file us up to date with the template
-# check_vars_template_diff: true
-
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-secrets_repo_url: ""
-
 with_tokman: false
 
-with_fedmsg: false
+# with_fedmsg: true
 
 # with_redis_commander: false
 
@@ -45,7 +36,7 @@ with_repository_cache: false
 with_sandbox: false
 
 # you can set the sandbox namespace name explicitly like this
-# sandbox_namespace: stream-stg-sandbox
+# sandbox_namespace: fedora-source-git-prod-sandbox
 
 # image to use for service
 # image: quay.io/packit/packit-service:{{ deployment }}
@@ -71,7 +62,7 @@ celery_retry_limit: 0
 # workers_short_running: 0
 # workers_long_running: 0
 
-distgit_url: https://gitlab.com/
-distgit_namespace: packit-service/rpms
+# distgit_url: https://src.fedoraproject.org/
+# distgit_namespace: rpms
 
 pushgateway_address: ""

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -9,7 +9,6 @@
 project: packit-prod
 
 # Openshift cluster url
-#host: https://console.pro-eu-west-1.openshift.com
 host: https://api.auto-prod.gi0n.p1.openshiftapps.com:6443
 
 # oc login <the above host value>, oc whoami -t

--- a/vars/packit/stg_template.yml
+++ b/vars/packit/stg_template.yml
@@ -9,7 +9,6 @@
 project: packit-stg
 
 # Openshift cluster url
-# host: https://console.pro-eu-west-1.openshift.com
 host: https://api.test-cluster.pxso.p1.openshiftapps.com:6443
 
 # oc login <the above host value>, oc whoami -t

--- a/vars/stream/prod_template.yml
+++ b/vars/stream/prod_template.yml
@@ -9,7 +9,6 @@
 project: stream-prod
 
 # Openshift cluster url
-# host: https://console.pro-eu-west-1.openshift.com
 host: https://api.auto-prod.gi0n.p1.openshiftapps.com:6443
 
 # oc login <the above host value>, oc whoami -t

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -8,8 +8,8 @@
 # Openshift project/namespace name
 project: myproject
 
-# Openshift cluster url (example: https://console.pro-eu-west-1.openshift.com)
-host: https://your-openshift-cluster-url
+# Openshift cluster url
+host: https://api.your-openshift-cluster-url:6443
 
 # oc login <the above host value>, oc whoami -t
 # OR via Openshift web GUI: click on your login in top right corner, 'Copy Login Command', take the part after --token=


### PR DESCRIPTION
There's no `stg_template.yml` because we don't have `stg` instance so far.