### PR TITLE
Rename the option `--git-dir` to `--git-repo`

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -85,15 +85,15 @@ def get_changelog(commits: List[Commit]) -> str:
     """,
 )
 @click.option(
-    "--git-dir",
+    "--git-repo",
     default=".",
     type=click.Path(dir_okay=True, file_okay=False),
     help="Git repository used for getting the changelog. "
     "Current directory is used by default.",
 )
 @click.argument("ref", type=click.STRING, required=False)
-def changelog(git_dir, ref):
-    print(get_changelog(get_relevant_commits(Repo(git_dir), ref)))
+def changelog(git_repo, ref):
+    print(get_changelog(get_relevant_commits(Repo(git_repo), ref)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There was an inconsistency between actual implementation in `changelog.py` (option --git-dir) and the [docs](https://github.com/packit/deployment/tree/main/scripts) (option --git-repo).