### PR TITLE
Give service more memory

### DIFF
--- a/docs/continuous-deployment.md
+++ b/docs/continuous-deployment.md
@@ -61,5 +61,7 @@ So when you happen to deploy broken worker and you want to revert/undo it
 because you don't know what's the cause/fix yet, you have to:
 
 1. `oc describe is/packit-worker` - select older image
-2. `oc tag --source=docker usercont/packit-worker@sha256:<older-hash> myproject/packit-worker:<deployment>`
+2. `oc tag --source=docker quay.io/packit/packit-worker@sha256:<older-hash> myproject/packit-worker:<deployment>`
    And see the `packit-worker-x` pods being re-deployed from the older image.
+3. Once you've built a fixed image, run
+   `oc tag quay.io/packit/packit-worker:<deployment> myproject/packit-worker:<deployment>`

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -73,7 +73,7 @@ spec:
           resources:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "196Mi"
+              memory: "320Mi"
               cpu: "200m"
             limits:
               # run_httpd.sh does 'alembic upgrade head' which might require more memory
@@ -81,7 +81,7 @@ spec:
               # you have to temporarily increase (in webUI/console) the limit
               # (2Gi@prod, 512Mi@stg was enough last time),
               # and once the alembic upgrade passes, revert.
-              memory: "196Mi"
+              memory: "320Mi"
               cpu: "200m"
           # In TLS world, hostname needs to match whatever is set in the cert
           # in our cause, k8s is doing here something like curl https://172.15.2.4:8443/api/healthz/


### PR DESCRIPTION
After [moving service to F35 & mod_wsgi-express](https://github.com/packit/packit-service/pull/1363) we were seeing some errors after the pod was running for some time.
As a workaround, we [restart the process(es) periodically](https://github.com/packit/packit-service/pull/1381), which helped on stg, but not on prod.
The culprit seems to be that now we need more memory. (Kudos to @TomasTomecek for spotting it.)
From metrics, the top was 247Mi so far, so I'm setting new requests/limits to 320Mi.


Note: I'll keep an eye on the metrics and merge this next week.