### PR TITLE
Move apiVersion: batch/v1beta1 to batch/v1 in cron jobs

### DIFF
--- a/cron-jobs/delete-pvcs/job-delete-pvcs.yaml
+++ b/cron-jobs/delete-pvcs/job-delete-pvcs.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: delete-pvcs

--- a/cron-jobs/import-images/README.md
+++ b/cron-jobs/import-images/README.md
@@ -1,9 +1,9 @@
 ## Periodically updating ImageStreams
 
-OpenShift Online seems to have turned off periodical updates from image registry
-to ImageStream (even we explicitly [request them](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/builds_and_image_streams.html#image-stream-mappings-working-periodic)).
+On prod, where we don't want the images to be imported as soon as they're built,
+we run this cron job to import them (end hence re-deploy) into image streams
+at the day & time (currently at 2AM on Tuesday) we want.
 
-As a work-around, there's a CronJob to periodically import images metadata into image streams.
 See [job-import-images.yaml](./job-import-images.yaml) and `oc describe cronjob.batch/import-images`.
 The job uses importimager [service account](https://docs.openshift.com/container-platform/3.11/dev_guide/service_accounts.html)
 with `registry-editor` [role](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_rbac.html) role added.

--- a/cron-jobs/import-images/job-import-images.yaml
+++ b/cron-jobs/import-images/job-import-images.yaml
@@ -13,7 +13,6 @@ spec:
           containers:
             - name: import-images
               image: quay.io/packit/import-images
-              imagePullPolicy: IfNotPresent
               env:
                 - name: KUBECONFIG
                   value: /tmp/.kube/config
@@ -21,6 +20,7 @@ spec:
                   value: https://api.auto-prod.gi0n.p1.openshiftapps.com:6443
                 # - name: SERVICE
                 #   value: stream
+                #   value: fedora-source-git
                 - name: DEPLOYMENT
                   value: prod
                 - name: TOKEN
@@ -30,6 +30,8 @@ spec:
                       name: importimager-token-gjfb6
                       # stream-prod @ auto
                       # name: importimager-token-lwwsk
+                      # fedora-source-git-prod @ auto
+                      # name: importimager-token-8wlrc
                       key: token
               resources:
                 limits:

--- a/cron-jobs/import-images/job-import-images.yaml
+++ b/cron-jobs/import-images/job-import-images.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: import-images

--- a/cron-jobs/packit-service-validation/openshift/job-run-validation.yaml
+++ b/cron-jobs/packit-service-validation/openshift/job-run-validation.yaml
@@ -1,7 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: packit-validation


### PR DESCRIPTION
`batch/v1` has been available since k8s v1.21 (Openshift 4.8)
`batch/v1beta1` will no longer be served in v1.25

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125