### PR TITLE
Use default number of max connections

### DIFF
--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -40,8 +40,6 @@ spec:
             # https://www.postgresql.org/docs/13/kernel-resources.html#LINUX-MEMORY-OVERCOMMIT
             - name: PG_OOM_ADJUST_FILE
               value: "/proc/self/oom_score_adj"
-            - name: POSTGRESQL_MAX_CONNECTIONS
-              value: "20"
           image: quay.io/centos7/postgresql-13-centos7
           imagePullPolicy: IfNotPresent
           name: postgres


### PR DESCRIPTION
In d9e8fb94 I set this to 20 because the default (100) looked like quite a lot in our case.

`SELECT count(*) FROM pg_stat_activity;` now shows over 20 (probably because of more workers?) so let's go back to the default.