### PR TITLE
Download secrets from Bitwarden vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vars/**/*.yml
 
 secrets/packit/
 secrets/stream/
+secrets/fedora-source-git/
 secrets/secrets.yaml
 
 # used in move_stable script

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=
 # https://docs.ansible.com/ansible/latest/user_guide/playbooks_tags.html#special-tags
 TAGS ?= all
 
-deploy:
+download-secrets:
+	./scripts/download_secrets.sh
+
+deploy: download-secrets
 	$(AP) playbooks/deploy.yml --tags $(TAGS)
 
 tags:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ TAGS ?= all
 download-secrets:
 	./scripts/download_secrets.sh
 
+# If you're sure you want to skip the secrets downloading,
+# because for example you just did it and you don't want to wait for it again
+# just set SKIP_SECRETS_SYNC or SSS to any value.
 deploy: download-secrets
 	$(AP) playbooks/deploy.yml --tags $(TAGS)
 

--- a/README.md
+++ b/README.md
@@ -28,21 +28,17 @@ This file documents basic usage, for more info see
 
 ## tl;dr How to deploy
 
-1. Obtain all the necessary [secrets](secrets/README.md).
-2. Configure the deployment by creating a variable file in 'vars/' from a
+1. Configure the deployment by creating a variable file in 'vars/' from a
    template as described in [vars/README](vars/README.md).
-3. `dnf install ansible origin-clients python3-openshift`
-4. `[SERVICE={service}] DEPLOYMENT={deployment} make deploy` (see
+2. `dnf install ansible origin-clients python3-openshift`
+3. `[SERVICE={service}] DEPLOYMENT={deployment} make deploy` (see
    [vars/README](vars/README.md)).
 
-By default, the playbook checks that the local copies of the deployment and
-secrets repositories are up to date, and the variable file used is up to
-date with the corresponding template.
+By default, the playbook checks that the local copy of the deployment is
+up-to-date, and the variable file used is
+up-to-date with the corresponding template.
 
-For these checks to work, you need to set `secrets_repo_url` in the variable
-file used.
-
-To disable all these check, set `check_up_to_date` to `false` in the
+To disable these checks, set `check_up_to_date` to `false` in the
 variable file.
 
 To only disable comparing the variable file to the template, set

--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@ Commander, run:
     $ DEPLOYMENT=dev TAGS="redis,redis-commander" make deploy
 
 Use `make tags` to list the currently available tags.
+
+## See [docs/](docs/) for more documentation.

--- a/docs/testing-changes.md
+++ b/docs/testing-changes.md
@@ -32,14 +32,18 @@ from the minishift environment after you start minishift:
 and then build worker & service images (`make worker; make service` in `packit-service` repo)
 with Docker, before you run `DEPLOYMENT=dev make deploy`.
 
+#### Generating secrets for local deployment
+
+See [secrets/README.md](../secrets/README.md)
+
 ### Staging (quick & reliable & but don't break it)
 
 If you're fairly sure your changes won't do any harm,
 you can temporarily get hold of staging instance for that.
 
-In case of `packit-worker`:
+For example, in case of `packit-worker`:
 
-- in packit-service repo:
+- in cloned [packit-service repo](https://github.com/packit/packit-service):
   - `make worker`
   - `podman tag quay.io/packit/packit-worker:dev quay.io/packit/packit-worker:stg`
   - `podman push quay.io/packit/packit-worker:stg`
@@ -47,17 +51,6 @@ In case of `packit-worker`:
 
 Once you're done you should [revert to older image](continuous-deployment.md#reverting-to-older-deploymentrevisionimage).
 Or it will be automatically replaced once a packit-service PR is merged.
-
-### Generating secrets for local packit-service deployment
-
-Local deployment of Packit service needs some secrets which can be generated using the steps listed below:
-
-1. Create `dev` directory under `secrets`
-2. Create a [new GitHub app](https://github.com/settings/apps/new) or [open existing one](https://github.com/settings/apps) and download key file as `secrets/dev/private-key.pem`
-3. Replace variables with your user specific values in `roles/generate-secrets/vars/main.yml`
-4. Run the playbook `make generate-local-secrets`
-
-Then, copy the `secrets` directory to your `packit-service` directory
 
 ## Zuul
 

--- a/docs/tls-certs.md
+++ b/docs/tls-certs.md
@@ -93,18 +93,11 @@ Go to the terminal with certbot command waiting for your action and hit Enter.
 
 Repeat this for all requested domains.
 
-### 4. Update secrets repository
+### 4. Update secrets in vault
 
-Copy certificates to secrets repository (prod & stg)
-
-    cp ~/.certbot/live/packit.dev/{fullchain,privkey}.pem <cloned secrets repo>/secrets/packit/prod/
-    cp ~/.certbot/live/packit.dev/{fullchain,privkey}.pem <cloned secrets repo>/secrets/packit/stg/
-    cp ~/.certbot/live/packit.dev/{fullchain,privkey}.pem <cloned secrets repo>/secrets/stream/prod/
-    cp ~/.certbot/live/packit.dev/{fullchain,privkey}.pem <cloned secrets repo>/secrets/stream/stg/
-    cp ~/.certbot/live/packit.dev/{fullchain,privkey}.pem <cloned secrets repo>/secrets/fedora-source-git/prod/
-    cp ~/.certbot/live/packit.dev/{fullchain,privkey}.pem <cloned secrets repo>/secrets/fedora-source-git/stg/
-
-Push, create merge request and merge.
+[Upload](https://bitwarden.com/help/attachments/#upload-a-file)
+`fullchain.pem` and `privkey.pem` from `~/.certbot/live/packit.dev/`
+to `secrets-tls-certs` item in our shared `Packit` collection in Bitwarden vault.
 
 ### 5.Re-deploy stg and prod environment:
 

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -43,13 +43,11 @@
     distgit_url: https://src.fedoraproject.org/
     distgit_namespace: rpms
     pushgateway_address: http://pushgateway
-    # Check that the deployment resources are up to date
+    # Check that the deployment repo is up-to-date
     check_up_to_date: true
-    # Check that the current vars file is up to date with the template
+    # Check that the current vars file is up-to-date with the template
     check_vars_template_diff: true
     deployment_repo_url: https://github.com/packit/deployment.git
-    # Needs to be defined in vars/
-    secrets_repo_url: ""
   tasks:
     - include_tasks: tasks/project-dir.yml
       tags:

--- a/playbooks/tasks/check-up-to-date.yml
+++ b/playbooks/tasks/check-up-to-date.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 ---
-- name: Check that the deployment resources are up to date
+- name: Check that the deployment resources are up-to-date
   when: zuul is not defined and check_up_to_date
   block:
     - name: Get HEAD from the remote
@@ -23,26 +23,7 @@
       ansible.builtin.assert:
         that:
           - remote_head.stdout.split()[0] == local_head.stdout
-        fail_msg: "The main branch of the deployment repo is not up to date"
-    - name: Check HEAD from secrets remote
-      ansible.builtin.command:
-        chdir: "{{ path_to_secrets }}"
-        cmd: "git ls-remote {{ secrets_repo_url }} master"
-      register: remote_secrets_head
-      changed_when: remote_secrets_head.rc != 0
-      failed_when: remote_secrets_head.rc != 0
-    - name: Check HEAD from local secrets
-      ansible.builtin.command:
-        chdir: "{{ path_to_secrets }}"
-        cmd: git show-ref -s refs/heads/master
-      register: local_secrets_head
-      changed_when: local_secrets_head.rc != 0
-      failed_when: local_secrets_head.rc != 0
-    - name: Compare secrets repo hashes
-      ansible.builtin.assert:
-        that:
-          - remote_secrets_head.stdout.split()[0] == local_secrets_head.stdout
-        fail_msg: "The master branch of the secrets repo is not up to date"
+        fail_msg: "The main branch of the deployment repo is not up-to-date"
     - name: Calculate the diff of the current vars file
       when: check_vars_template_diff
       ansible.builtin.shell:
@@ -50,7 +31,7 @@
         # Remove the keys expected to be different and lines specific to the diff-format.
         cmd: >-
           diff vars/{{ service }}/{{ deployment }}.yml vars/{{ service }}/{{ deployment }}_template.yml |
-          sed '/api_key/d;/secrets_repo_url/d;/[0-9]\+c[0-9]\+/d;/---/d'
+          sed '/api_key/d;/[0-9]\+c[0-9]\+/d;/---/d'
       register: diff
       changed_when: diff.rc != 0
       failed_when: diff.rc != 0
@@ -62,5 +43,5 @@
         fail_msg: >-
           The diff between
           'vars/{{ service }}/{{ deployment }}.yml' and
-          'vars/{{ service }}/{{ deployment }}_template.yml' is has some
+          'vars/{{ service }}/{{ deployment }}_template.yml' has some
           unexpected lines: {{ diff.stdout }}

--- a/scripts/download_secrets.sh
+++ b/scripts/download_secrets.sh
@@ -39,9 +39,7 @@ elif ! bw unlock --check; then
   BW_SESSION="$(bw unlock --raw)"
   export BW_SESSION
 fi
-
-# Debug
-bw unlock --check
+bw unlock --check || { echo >&2 "Failed to unlock vault"; exit 1; }
 
 # Pull the latest vault data from server
 bw sync

--- a/scripts/download_secrets.sh
+++ b/scripts/download_secrets.sh
@@ -14,8 +14,9 @@
 # For example I (jpopelka) have this in my ~/.bashrc
 # alias bwunlock='bw unlock --check || export BW_SESSION="$(bw unlock --raw)"'
 
-# Debug
-#set -x
+# If run via 'make deploy', you can use this (on your own risk) to
+# not download secrets again, if you just did it.
+[[ -n "${SKIP_SECRETS_SYNC}" || -n "${SSS}" ]] && { echo "Not downloading secrets"; exit 0; }
 
 # Where to download the files
 DEFAULT_PATH_TO_SECRETS="secrets/${SERVICE}/${DEPLOYMENT}/"

--- a/scripts/download_secrets.sh
+++ b/scripts/download_secrets.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/bash
+
+# Script to
+# - login to Bitwarden and/or unlock the vault
+# - download all files attached to secrets-${SERVICE}-${DEPLOYMENT} note
+#   into secrets/${SERVICE}/${DEPLOYMENT}/
+# Example usage:
+# SERVICE=packit DEPLOYMENT=stg PATH_TO_SECRETS=/tmp/xyz/ ./scripts/download_secrets.sh
+
+# If you're about to run this script more times,
+# you better run 'bw login || bw unlock' yourself and export the returned BW_SESSION
+# so that this script doesn't ask you for the master password every time.
+# For example I (jpopelka) have this in my ~/.bashrc
+# alias bwunlock='bw unlock --check || export BW_SESSION="$(bw unlock --raw)"'
+
+# Debug
+#set -x
+
+# Where to download the files
+DEFAULT_PATH_TO_SECRETS="secrets/${SERVICE}/${DEPLOYMENT}/"
+
+# Set default values if not set already
+: "${SERVICE:=packit}"
+: "${DEPLOYMENT:=dev}"
+[[ "${DEPLOYMENT}" == "dev" ]] && { echo "Not downloading secrets for DEPLOYMENT==dev"; exit 0; }
+: "${PATH_TO_SECRETS:=$DEFAULT_PATH_TO_SECRETS}"
+
+# Name of the shared (Bitwarden vault) secure note,
+# which contains the secret files as attachments.
+BW_ITEM="secrets-${SERVICE}-${DEPLOYMENT}"
+
+command -v bw >/dev/null 2>&1 || { echo >&2 "'bw' command not found, see https://bitwarden.com/help/cli"; exit 1; }
+
+# Debug
+bw status
+
+if ! bw login --check; then
+  bw login
+# The vault unlocks once you login. It can however happen
+# that you're already logged in, but the vault is locked.
+elif ! bw unlock --check; then
+  BW_SESSION="$(bw unlock --raw)"
+  export BW_SESSION
+fi
+
+# Debug
+bw unlock --check
+
+# Pull the latest vault data from server
+bw sync
+
+# Get the item id first
+ITEM_ID=$(bw get item "${BW_ITEM}" | jq -r .id)
+[[ -z ${ITEM_ID} ]] && { echo >&2 "Couldn't find ${BW_ITEM} in Bitwarden vault"; exit 1; }
+
+# Download all attachments of that item
+bw get item "${BW_ITEM}" | jq -r .attachments[].id | xargs -L1 bw get attachment --itemid "${ITEM_ID}" --output "${PATH_TO_SECRETS}"

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,31 +1,13 @@
-# Place your secrets inside this directory.
+## Secrets
 
-You'll find those in our super-secret repo in internal Gitlab.
-Just symlink/copy it here.
+Deployment process (`make deploy`) expects files to be transformed to
+Openshift secrets to be found in these subdirectories.
+These files are either automatically downloaded (`make download-secrets`)
+or they need to be created manually in case of local/dev/test deployment.
 
-## What secrets do you need?
+## What secret files the deployment expects
 
-```
-.
-└── secrets
-    ├── packit/stream
-    │   │   ├── prod/stg
-    │   │   ├── copr
-    │   │   ├── extra-vars.yml
-    │   │   ├── fedora.keytab
-    │   │   ├── fedora.toml
-    │   │   ├── fullchain.pem
-    │   │   ├── id_rsa
-    │   │   ├── id_rsa.pub
-    │   │   ├── packit-service.yaml
-    │   │   ├── private-key.pem
-    │   │   ├── privkey.pem
-    │   │   ├── sentry_key
-    │   │   └── ssh_config
-
-```
-
-Some of them are pre-filled in [template](/secrets/template) directory.
+Some of them are pre-filled in the [template](/secrets/template) directory.
 
 - `copr` - Your copr credentials. See pre-filled template in [templates directory](/secrets/template/copr).
 - `extra-vars.yml` - Secrets for Postgresql & Redis.
@@ -37,3 +19,5 @@ Some of them are pre-filled in [template](/secrets/template) directory.
 - `private-key.pem` - Specified in a Github App settings. Used to [sign access token requests](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app).
 - `sentry_key` - Sentry DSN.
 - `ssh_config` - SSH configuration to be able to run fedpkg inside of the OpenShift pod. See pre-filled template in [templates directory](/secrets/template/ssh_config).
+
+Not all services expect all of them. For example source-git services don't need `copr` & `private-key.pem`.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -7,6 +7,7 @@ or they need to be created manually in case of local/dev/test deployment.
 
 ## What secret files the deployment expects
 
+Not all services expect all of them. For example source-git services don't need `copr` & `private-key.pem`.
 Some of them are pre-filled in the [template](/secrets/template) directory.
 
 - `copr` - Your copr credentials. See pre-filled template in [templates directory](/secrets/template/copr).
@@ -20,4 +21,32 @@ Some of them are pre-filled in the [template](/secrets/template) directory.
 - `sentry_key` - Sentry DSN.
 - `ssh_config` - SSH configuration to be able to run fedpkg inside of the OpenShift pod. See pre-filled template in [templates directory](/secrets/template/ssh_config).
 
-Not all services expect all of them. For example source-git services don't need `copr` & `private-key.pem`.
+## Running a service/bot locally
+
+To deploy a {SERVICE} into your [local Openshift cluster](../docs/testing-changes.md),
+run `SERVICE=the-service DEPLOYMENT=dev make deploy`.
+
+Local deployment needs some secrets which can be obtained using the steps listed below:
+
+- Create `dev` directory under `secrets/{SERVICE}/`
+- Replace variables with your user specific values in `roles/generate-secrets/vars/main.yml`
+- Generate the secrets either by running `make generate-local-secrets` or manually.
+
+### How to populate {SERVICE}/dev/ manually
+
+The easiest is to download `stg/` secrets (`DEPLOYMENT=stg make download-secrets`),
+copy into `dev/` and do some tweaks there - like:
+
+- `packit-service.yaml`:
+  - `deployment: stg` -> `deployment: dev`
+  - `fas_user: packit` -> `fas_user: your-fas-username`
+  - `validate_webhooks: true` -> `validate_webhooks: false`
+  - `server_name: stg.packit.dev` -> `server_name: service.localhost:8443`
+  - would be nice to use your tokens/api keys in `authentication`, but it's not crucial since it's for staging instances
+- `sentry_key`: just empty it to not send your devel bugs to Sentry
+- `copr`: would be nice to use [your own token](https://copr.fedorainfracloud.org/api/) if you're planning to build in Copr
+- `fedora.toml`: there's (2x) unique queue uuid which needs to be replaced with a new generated (`uuidgen`) one
+  (if you'll run [fedmsg](https://github.com/packit/packit-service-fedmsg))
+- `id_rsa[.pub]`: replace with your ssh keys
+
+Not all services use all of them. For example `copr` is needed only by `packit` service.

--- a/vars/packit/dev_template.yml
+++ b/vars/packit/dev_template.yml
@@ -18,14 +18,11 @@ api_key: ""
 # To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
 validate_certs: false
 
-# Don't check that the deployment resources are up to date
+# Don't check that the deployment resources are up-to-date
 check_up_to_date: false
 
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
-
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-# secrets_repo_url: ""
 
 # with_tokman: true
 

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -17,14 +17,11 @@ api_key: ""
 
 # validate_certs: true
 
-# Check that the deployment resources are up to date
+# Check that the deployment resources are up-to-date
 # check_up_to_date: true
 
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
-
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-secrets_repo_url: ""
 
 # with_tokman: true
 

--- a/vars/packit/stg_template.yml
+++ b/vars/packit/stg_template.yml
@@ -16,14 +16,11 @@ host: https://api.test-cluster.pxso.p1.openshiftapps.com:6443
 api_key: ""
 # validate_certs: true
 
-# Check that the deployment resources are up to date
+# Check that the deployment resources are up-to-date
 # check_up_to_date: true
 
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
-
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-secrets_repo_url: ""
 
 # with_tokman: true
 

--- a/vars/stream/dev_template.yml
+++ b/vars/stream/dev_template.yml
@@ -18,14 +18,11 @@ api_key: ""
 # To work-around 'SSL: CERTIFICATE_VERIFY_FAILED'
 validate_certs: false
 
-# Don't check that the deployment resources are up to date
+# Don't check that the deployment resources are up-to-date
 check_up_to_date: false
 
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
-
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-# secrets_repo_url: ""
 
 with_tokman: false
 

--- a/vars/stream/prod_template.yml
+++ b/vars/stream/prod_template.yml
@@ -17,14 +17,11 @@ api_key: ""
 
 # validate_certs: true
 
-# Check that the deployment resources are up to date
+# Check that the deployment resources are up-to-date
 # check_up_to_date: true
 
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
-
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-secrets_repo_url: ""
 
 with_tokman: false
 

--- a/vars/stream/stg_template.yml
+++ b/vars/stream/stg_template.yml
@@ -17,14 +17,11 @@ api_key: ""
 
 # validate_certs: true
 
-# Check that the deployment resources are up to date
+# Check that the deployment resources are up-to-date
 # check_up_to_date: true
 
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
-
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-secrets_repo_url: ""
 
 with_tokman: false
 

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -16,14 +16,12 @@ host: https://api.your-openshift-cluster-url:6443
 api_key: ""
 # validate_certs: true
 
-# Check that the deployment resources are up to date
+# Check that the deployment resources are up-to-date
 # check_up_to_date: true
 
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
 
-# Git URL ("Clone with SSH") of the repository where secrets are stored
-secrets_repo_url: ""
 # with_tokman: true
 
 # if you want to deploy fedmsg, please make sure to


### PR DESCRIPTION
Add a `download-secrets` make target, which calls new `scripts/download-secrets.sh`, which:
- logins to Bitwarden and/or unlocks the vault
- downloads all files attached to `secrets-${SERVICE}-${DEPLOYMENT}` and `secrets-tls-certs` notes into `secrets/${SERVICE}/${DEPLOYMENT}/`

Example usage: `SERVICE=packit DEPLOYMENT=stg make deploy TAGS=secrets` downloads secrets into `secrets/packit/stg/` and re-deploys them into packit-stg.