### PR TITLE
Use production distgit for packit-stg

### DIFF
--- a/vars/packit/stg_template.yml
+++ b/vars/packit/stg_template.yml
@@ -76,5 +76,4 @@ api_key: ""
 # workers_short_running: 0
 # workers_long_running: 0
 
-distgit_url: https://src.stg.fedoraproject.org/
 # pushgateway_address: http://pushgateway


### PR DESCRIPTION
By removing the playbook variable,
we don't set it as env. var and value from service config is used (defaults to prod instance).

Signed-off-by: Frantisek Lachman <flachman@redhat.com>