### PR TITLE
fix: ignore comments in script for python dependencies

### DIFF
--- a/containers/Dockerfile.base
+++ b/containers/Dockerfile.base
@@ -7,5 +7,5 @@ ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
     ANSIBLE_STDOUT_CALLBACK=debug
 
 RUN dnf update -y && \
-    dnf install -y ansible python3-pip && \
+    dnf install -y ansible python3-pip python3-packaging && \
     dnf clean all

--- a/scripts/setupcfg2rpm.py
+++ b/scripts/setupcfg2rpm.py
@@ -24,6 +24,7 @@ import configparser
 
 def normalize_name(name: str) -> str:
     """https://www.python.org/dev/peps/pep-0503/#normalized-names"""
+    name = name.split(";")[0]  # in case there is a comment
     return re.sub(r"[-_.]+", "-", name).lower()
 
 

--- a/scripts/setupcfg2rpm.py
+++ b/scripts/setupcfg2rpm.py
@@ -20,12 +20,28 @@ import re
 import pathlib
 import argparse
 import configparser
+from typing import Optional
+
+from packaging.requirements import Requirement
 
 
 def normalize_name(name: str) -> str:
     """https://www.python.org/dev/peps/pep-0503/#normalized-names"""
-    name = name.split(";")[0]  # in case there is a comment
     return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def evaluate_marker(req: str) -> Optional[str]:
+    """Evaluate the marker in a requirement string
+
+    Args:
+        req: Requirement string to be evaluated.
+
+    Returns:
+        The name of the requirement if there is no marker or the marker
+        evaluates to True, None otherwise.
+    """
+    req: Requirement = Requirement(req)
+    return req.name if not req.marker or req.marker.evaluate() else None
 
 
 if __name__ == "__main__":
@@ -41,7 +57,9 @@ if __name__ == "__main__":
     config = configparser.ConfigParser()
     with open(setupcfg_path) as f:
         config.read_file(f)
-        python_packages = config["options"]["install_requires"].strip().splitlines()
+        requirements = config["options"]["install_requires"].strip().splitlines()
+
+    python_packages = filter(None, map(evaluate_marker, requirements))
 
     result = [
         f"python3dist({normalize_name(pkg_name)})" for pkg_name in python_packages


### PR DESCRIPTION
Strip away comment if it is put with the dependency name.

Caused by packit/ogr#710

Signed-off-by: Matej Focko <mfocko@redhat.com>