### PR TITLE
Pre-generate blogpost from release notes

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -28,14 +28,21 @@ def get_relevant_commits(repository: Repo, ref: Optional[str]) -> List[Commit]:
     return list(repository.iter_commits(rev=range, merges=True))
 
 
-def get_pr_data(message: str) -> str:
+def get_pr_data(message: str, repo: Optional[str] = None) -> str:
     """
     obtain PR ID and produce a markdown link to it
+
+    if repo is set, creates a markdown link to the given repo (useful for blogposts)
     """
     # Merge pull request #1483 from majamassarini/fix/1357
     first_line = message.split("\n")[0]
     fourth_word = first_line.split(" ")[3]
-    return fourth_word
+    if repo:
+        pr_id = fourth_word.lstrip("#")
+        url = f"https://github.com/packit/{repo}/pull/{pr_id}"
+        return f"[{repo}#{pr_id}]({url})"
+    else:
+        return fourth_word
 
 
 def convert_message(message: str) -> Optional[str]:
@@ -50,14 +57,14 @@ def convert_message(message: str) -> Optional[str]:
     return None
 
 
-def get_changelog(commits: List[Commit]) -> str:
+def get_changelog(commits: List[Commit], repo: Optional[str] = None) -> str:
     changelog = ""
     for commit in commits:
         if PRE_COMMIT_CI_MESSAGE in commit.message:
             continue
         message = convert_message(commit.message)
         if message and message.lower() not in NOT_IMPORTANT_VALUES:
-            suffix = get_pr_data(commit.message)
+            suffix = get_pr_data(commit.message, repo)
             changelog += f"- {message} ({suffix})\n"
     return changelog
 

--- a/scripts/move_stable.py
+++ b/scripts/move_stable.py
@@ -3,12 +3,15 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import click
-
 from datetime import date, datetime, timedelta
 from pathlib import Path
 import subprocess
-from typing import List
+from typing import List, Optional
+
+import click
+from git import Repo
+
+import changelog
 
 
 NAMESPACE: str = "packit"
@@ -21,6 +24,10 @@ REPOSITORIES: List[str] = [
     "tokman",
     "packit-service",
     "hardly",
+]
+REPOS_FOR_BLOG: List[str] = [
+    "packit",
+    "packit-service",
 ]
 STABLE_BRANCH: str = "stable"
 ROLLING_BRANCH: str = "main"
@@ -123,6 +130,10 @@ def move_repository(repository: str, remote: str, repo_store: str) -> None:
 
     REPOSITORIES are Git repositories cloned to repo store.
 
+    Once the stable branches are moved, a blogpost template describing the
+    work done in the last week is output. The entries are collected from
+    the following repositories: {', '.join(REPOS_FOR_BLOG)}.
+
     Example:
 
     To move the \'{STABLE_BRANCH}\' branch in all the repositories,
@@ -162,6 +173,8 @@ def move_all(ctx, remote, repo_store: str) -> None:
             move_repository, repository=repository, remote=remote, repo_store=repo_store
         )
 
+    create_blogpost(remote, repo_store)
+
 
 @cli.command(
     short_help="Prints an URL GitHub query for pull requests that has release notes."
@@ -198,6 +211,39 @@ def github_query(till: datetime) -> None:
             label="has-release-notes",
         )
     )
+
+
+def format_day(day: int) -> str:
+    suffixes = ["th", "st", "nd", "rd"]
+    if day % 10 in (1, 2, 3) and day not in (11, 12, 13):
+        suffix = suffixes[day % 10]
+        return f"{day}{suffix}"
+    else:
+        return f"{day}{suffixes[0]}"
+
+
+def format_date(to_format: date) -> str:
+    month = to_format.strftime("%B")
+    day = format_day(to_format.day)
+    return f"{month} {day}"
+
+
+def create_blogpost(remote: str, repo_store: str, till: Optional[datetime] = None):
+    till = (till or datetime.today()).date()
+
+    click.echo(
+        "Here is a template for this week's blogpost (modifications may be needed)\n"
+    )
+    # Get the start of the week and its number, we consider Tue - Mon (6 days)
+    since = till - timedelta(days=6)
+    week_number = since.isocalendar()[1]
+    click.echo(f"## Week {week_number} ({format_date(since)} - {format_date(till)})\n")
+    for repo in REPOS_FOR_BLOG:
+        path_to_repository = Path(repo_store, repo).absolute()
+        git_repo = Repo(path_to_repository)
+        main_hash = get_reference(path_to_repository, remote, ROLLING_BRANCH)[:7]
+        commits = git_repo.iter_commits(main_hash, merges=True, since=since)
+        click.echo(changelog.get_changelog(commits, repo).rstrip())
 
 
 def get_reference(path_to_repository: Path, remote: str, branch: str) -> str:


### PR DESCRIPTION
Example output (setting till=Monday) after fetching the repos (the next service guru will need to check that it actually works well after moving stable branches :-)):

```md
Here is a template for this week's blogpost (modifications may be needed)

## Week 18 (May 3rd - May 9th)

- When initializing source-git repos, the author of downstream commits created from patch files which are not in a git-am format is set to the original author of the patch-file in dist-git, instead of using the locally configured Git author. ([packit#1575](https://github.com/packit/packit/pull/1575))
- Packit now correctly inform users about downstream errors only on the last try. (Previously, Packit informed for all tries even the last try succeded.) ([packit-service#1485](https://github.com/packit/packit-service/pull/1485))
```

Fixes: #317 