### PR TITLE
Fix setting defaults in download_secrets.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ This file documents basic usage, for more info see
 
 1. Configure the deployment by creating a variable file in 'vars/' from a
    template as described in [vars/README](vars/README.md).
-2. `dnf install ansible origin-clients python3-openshift`
+2. Install some dependencies:
+   - `dnf install ansible python3-openshift jq make`
+   - `dnf install origin-clients` or (for a more recent version) download
+     `openshift-client-linux` from the [OKD
+     releases](https://github.com/openshift/okd/releases) page, unpack it, and
+     place `oc` in your `$PATH` (ex: `~/.local/bin`).
+   - Download the [Bitwarden
+     CLI](https://bitwarden.com/help/cli/#download-and-install),
+     unpack and place it in your `$PATH` (ex: `~/.local/bin`).
 3. `[SERVICE={service}] DEPLOYMENT={deployment} make deploy` (see
    [vars/README](vars/README.md)).
 


### PR DESCRIPTION
And update the docs on what dependencies to install.

Replace the second `bw unlock --check` with a check for the
`BW_SESSION` environment variable, as I found `bw unlock --check`
reporting a locked vault, right after a vault was successfully unlocked.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>