### PR TITLE
Add fluentd sidecar to worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This file documents basic usage, for more info see
   - [Packit service deployment specifics](docs/packit-service.md)
   - [Fedora source-git bot deployment specifics](docs/fedora-source-git.md)
   - [CentOS Stream source-git bot deployment specifics](docs/centos-stream-source-git.md)
+  - [Logs](docs/logs.md) - how we aggregate worker logs and where to find them
 - [playbooks/](playbooks/) - Ansible playbooks
 - [roles/](roles/) - Ansible roles
 - [vars/](vars/) - Variable file(s). See [vars/README.md](vars/README.md).

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,32 @@
+## [Logs aggregation](https://github.com/packit/research/tree/main/logs-aggregation)
+
+When a worker pod is restarted (due to image or cluster update), the pod logs are gone.
+To work around this, each worker pod has a sidecar container which runs [Fluentd](https://docs.fluentd.org).
+Fluentd is a data collector which allows us to get the logs from a worker via
+[syslog](https://docs.fluentd.org/input/syslog) and send them someplace to be stored permanently.
+Currently, until we figure out how to send the logs to Splunk,
+we're [sending them to files](https://docs.fluentd.org/output/file) in a persistent volume mount to
+`/var/log/packit/` in the fluentd container.
+
+We use [our fluentd-splunk-hec image](https://quay.io/repository/packit/fluentd-splunk-hec),
+built via [a workflow](https://github.com/jpopelka/fluent-plugin-splunk-hec/blob/main/.github/workflows/rebuild-and-push-image.yml)
+because we don't want to use [docker.io/splunk/fluentd-hec image](https://hub.docker.com/r/splunk/fluentd-hec).
+
+### Where do I find the logs?
+
+Select a worker pod -> `Terminal` -> `fluentd sidecar`
+
+    $ cd /var/log/packit
+    $ ls -lah
+    $ gzip -d .20221006_0.log.gz
+    $ less .20221006_0.log
+
+You can see also a `buffer.*.log` file which contains today's logs.
+It'll be flushed and compressed into a permanent gzip file at the end of the day.
+
+### What is missing?
+
+The format of the log files is not much readable as it contains all the info from syslog.
+Eventually, we want to send the logs to Splunk.
+Until then, it can happen that the (1Gi) space on the permanent volumes gets depleted.
+To delete old (>7d) log files, run `find /var/log/packit -mtime +7 -delete`.

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -34,6 +34,13 @@ spec:
           requests:
             storage: {{ repository_cache_storage }}
 {% endif %}
+    - metadata:
+        name: logs
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 1Gi
   updateStrategy.type: RollingUpdate
   podManagementPolicy: OrderedReady
   template:
@@ -53,6 +60,8 @@ spec:
           secret: {secretName: packit-secrets}
         - name: packit-config
           secret: {secretName: packit-config}
+        - name: fluentd-config
+          configMap: {name: fluentd-config}
       containers:
         - name: packit-worker
           image: packit-worker:{{ deployment }}
@@ -97,6 +106,9 @@ spec:
             - name: POOL
               value: gevent
 {% endif %}
+            - name: SYSLOG_HOST
+              # localhost doesn't work
+              value: "127.0.0.1"
           volumeMounts:
             - name: packit-ssh
               mountPath: /packit-ssh
@@ -120,6 +132,25 @@ spec:
             limits:
               memory: {{ worker_limits_memory }}
               cpu: {{ worker_limits_cpu }}
+        # See ../docs/logs.md
+        - name: fluentd-sidecar
+          image: fluentd:{{ deployment }}
+          ports:
+            - containerPort: 5140
+              protocol: UDP
+          env:
+            - name: SPLUNK_HEC_HOST
+              valueFrom: {secretKeyRef: {name: splunk, key: hec-host}}
+            - name: SPLUNK_HEC_PORT
+              valueFrom: {secretKeyRef: {name: splunk, key: hec-port}}
+            - name: SPLUNK_HEC_TOKEN
+              valueFrom: {secretKeyRef: {name: splunk, key: hec-token}}
+          volumeMounts:
+            - name: fluentd-config
+              mountPath: /fluentd/etc
+              readOnly: true
+            - name: logs
+              mountPath: /var/log/packit
 ---
 kind: ImageStream
 apiVersion: image.openshift.io/v1
@@ -131,6 +162,51 @@ spec:
       from:
         kind: DockerImage
         name: {{ image_worker }}
+      importPolicy:
+        # Periodically query registry to synchronize tag and image metadata.
+        scheduled: {{ auto_import_images }}
+  lookupPolicy:
+    # allows all resources pointing to this image stream to use it in the image field
+    local: true
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: fluentd-config
+data:
+  fluent.conf: |
+    <system>
+      log_level debug
+    </system>
+    <source>
+      @type syslog
+      <parse>
+        message_format rfc5424
+      </parse>
+      tag packit
+    </source>
+    <match packit.**>
+      @type file
+      path /var/log/packit/
+      compress gzip
+    </match>
+    <match packit.**>
+      @type splunk_hec
+      hec_host "#{ENV['SPLUNK_HEC_HOST']}"
+      hec_port "#{ENV['SPLUNK_HEC_PORT']}"
+      hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
+    </match>
+---
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: fluentd
+spec:
+  tags:
+    - name: {{ deployment }}
+      from:
+        kind: DockerImage
+        name: {{ image_fluentd }}
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
         scheduled: {{ auto_import_images }}

--- a/openshift/secret-splunk.yml.j2
+++ b/openshift/secret-splunk.yml.j2
@@ -1,0 +1,13 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: splunk
+type: Opaque
+data:
+  hec-host: "{{ splunk_hec_host | b64encode }}"
+  hec-port: "{{ splunk_hec_port | b64encode }}"
+  hec-token: "{{ splunk_hec_token | b64encode }}"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -26,6 +26,7 @@
     image_fedmsg: quay.io/packit/packit-service-fedmsg:{{ deployment }}
     image_dashboard: quay.io/packit/dashboard:{{ deployment }}
     image_tokman: quay.io/packit/tokman:{{ deployment }}
+    image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
     # project_dir is set in tasks/project-dir.yml
     path_to_secrets: "{{ project_dir }}/secrets/{{ service }}/{{ deployment }}"
     # to be used in Image streams as importPolicy:scheduled value
@@ -137,6 +138,7 @@
         - "{{ lookup('template', '{{ project_dir }}/openshift/secret-sentry.yml.j2') }}"
         - "{{ lookup('template', '{{ project_dir }}/openshift/secret-postgres.yml.j2') }}"
         - "{{ lookup('template', '{{ project_dir }}/openshift/secret-aws.yml.j2') }}"
+        - "{{ lookup('template', '{{ project_dir }}/openshift/secret-splunk.yml.j2') }}"
       tags:
         - secrets
 

--- a/vars/fedora-source-git/prod_template.yml
+++ b/vars/fedora-source-git/prod_template.yml
@@ -40,6 +40,10 @@ with_sandbox: false
 
 # image to use for worker
 image_worker: quay.io/packit/hardly:{{ deployment }}
+
+# image to use for fluentd sidecar
+# image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
+
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 

--- a/vars/fedora-source-git/stg_template.yml
+++ b/vars/fedora-source-git/stg_template.yml
@@ -40,6 +40,10 @@ with_sandbox: false
 
 # image to use for worker
 image_worker: quay.io/packit/hardly:{{ deployment }}
+
+# image to use for fluentd sidecar
+# image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
+
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -60,6 +60,9 @@ repository_cache_storage: 10Gi
 # image to use for tokman
 # image_tokman: "quay.io/packit/tokman:{{ deployment }}"
 
+# image to use for fluentd sidecar
+# image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
+
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 

--- a/vars/packit/stg_template.yml
+++ b/vars/packit/stg_template.yml
@@ -58,6 +58,9 @@ with_flower: true
 # image to use for tokman
 # image_tokman: "quay.io/packit/tokman:{{ deployment }}"
 
+# image to use for fluentd sidecar
+# image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
+
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 

--- a/vars/stream/prod_template.yml
+++ b/vars/stream/prod_template.yml
@@ -46,6 +46,10 @@ with_sandbox: false
 
 # image to use for worker
 image_worker: quay.io/packit/hardly:{{ deployment }}
+
+# image to use for fluentd sidecar
+# image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
+
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 

--- a/vars/stream/stg_template.yml
+++ b/vars/stream/stg_template.yml
@@ -46,6 +46,10 @@ with_sandbox: false
 
 # image to use for worker
 image_worker: quay.io/packit/hardly:{{ deployment }}
+
+# image to use for fluentd sidecar
+# image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
+
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 

--- a/vars/template.yml
+++ b/vars/template.yml
@@ -59,6 +59,9 @@ api_key: ""
 # image to use for tokman
 # image_tokman: "quay.io/packit/tokman:{{ deployment }}"
 
+# image to use for fluentd sidecar
+# image_fluentd: quay.io/packit/fluentd-splunk-hec:latest
+
 # Path to secrets (in case you don't have it in the root of this project)
 # path_to_secrets: ../secrets
 


### PR DESCRIPTION
https://github.com/packit/research/pull/152

We use our image https://quay.io/repository/packit/fluentd-splunk-hec, built via [a GitHub workflow](https://github.com/jpopelka/fluent-plugin-splunk-hec/blob/main/.github/workflows/rebuild-and-push-image.yml) because we don't want to use [docker.io/splunk/fluentd-hec image](https://hub.docker.com/r/splunk/fluentd-hec).

I've been unsuccessful in sending data to Splunk HEC so far.
This is a middle step to make sure the fluentd sidecar works OK and at this moment we're [sending logs to files](https://docs.fluentd.org/output/file) in a persistent volume mount to `/var/log/packit/` in the fluentd container.

Once a day is the intermediate `buffer.*.log` file in `/var/log/packit/` flushed and compressed into a permanent gzip file.
The file is `.` prefixed, so use `ls -a` to see it.

The `fluentd-config` has also a match section with `@type splunk_hec`, but it's not matched :) now because the preceding `@type file` is matched first.

The fluentd sidecar has no resource requests/limits because with it the fluentd was starting very slow (about 10sec) and it missed some logs from worker which was already up and processing.