### PR TITLE
Improve the process to allow custom Copr projects

### DIFF
--- a/docs/allow-custom-copr-projects.md
+++ b/docs/allow-custom-copr-projects.md
@@ -1,0 +1,115 @@
+# Configure projects to be built in custom Copr repositories
+
+By default Packit builds PRs in it's own namespace in Copr. It's possible
+though to configure it to use a dedicated Copr repository by setting a
+`project` and an `owner` config value.
+
+But Packit should build only the allowed GitHub projects in these Copr
+repositories. As a temporary solution, the mapping of Copr repositories to
+GitHub projects is configured in the service configuration in
+`packit-service.yaml`, using the `allowed_forge_projects_for_copr_project`
+key.
+
+Bellow are the steps to update this configuration when a user asks for some
+GitHub projects to be allowed to build in a Copr repo.
+
+## 1. Check that the request is legitimate
+
+The user doing the request should be the owner of the Copr repository, or they
+should be a member of the group owning the Copr repo.
+
+The user doing the request should already have commits in the `main` branch of
+the GitHub projects they are referring to.
+
+If mapping the users chat handle or email address to their Fedora Account or
+GitHub account is not unequivocal, send them a GPG encrypted message using
+their SSH key in Fedora Accounts, and ask them to decrypt it and tell you the
+content of it, in order to make sure that things fit.
+
+If you have doubts with the above, ask for help :-)
+
+## 2. Update the service config in stage
+
+Although this might be not strictly required (Packit Stage might not be
+enabled for the projects you are going to add), it's a good exercise to make
+sure you are doing everything right.
+
+1. Download the latest secrets from Bitwarden. In `packit/deployment` run:
+
+   ```
+   $ SERVICE=packit DEPLOYMENT=stg make download-secrets
+   ```
+
+2. Edit `packit-service.yaml` and add the new mapping.
+
+   ```
+   $ $EDITOR secrets/packit/stg/packit-service.yaml
+   ```
+
+   In case of group owned Copr repos the change is going to look like this:
+
+   ```yaml
+   allowed_forge_projects_for_copr_project:
+     "@<group>/<repo>":
+       - github.com/<namespace>/<project>
+   ```
+
+   For Copr repos owned by individuals:
+
+   ```yaml
+   allowed_forge_projects_for_copr_project:
+     "<user>/<repo>":
+       - github.com/<namespace>/<project1>
+       - github.com/<namespace>/<project2>
+   ```
+
+   There can be multiple GitHub projects allowed to be built in the same Copr
+   repo.
+
+   Test that `packit-service.yaml` is a valid YAML. Use Python or
+   [yq](https://github.com/mikefarah/yq) for this.
+
+3. Login to the stage cluster and select the stage namespace:
+
+   ```
+   $ oc login ...
+   $ oc project packit-stg
+   ```
+
+4. Update the OpenShift secret:
+
+   ```
+   $ scripts/update_oc_secret.sh packit-config secrets/packit/stg/packit-service.yaml
+   ```
+
+5. Save the new config to Bitwarden:
+
+   ```
+   $ scripts/update_bw_secret.sh secrets/packit/stg/packit-service.yaml
+   ```
+
+6. Respin all the worker pods to pick up the change, by first scaling the
+   stateful sets to 0 replicas, and then scaling them back to the original
+   number.
+
+   To check the current worker stateful sets, run `oc get sts`.
+
+   Scale to 0: `oc scale sts/packit-worker --replicas=0`. Wait till there are
+   0 replicas ready.
+
+   Scale back: `oc scale sts/packit-worker --replicas=1`.
+
+   Check that all worker pods are running okay, and there are no errors in the
+   logs.
+
+## 3. Update the service config in prod
+
+This is the same as doing it in stage, just replace `stg` with `prod`.
+
+In prod there might be more types of workers (`packit-worker`,
+`packit-worker-short-running`, `packit-worker-long-running`). All of them
+need to be respinned.
+
+## 4. Let the user know that the change was made
+
+And ask them to confirm that things are working.

--- a/scripts/update_bw_secret.sh
+++ b/scripts/update_bw_secret.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/bash
+
+# Script to update the attachement of a secret item in Bitwarden
+#
+# Here is the workflow how to do that:
+#
+# 1. Make sure your local copy is up to date. For example:
+#
+#     $ SERVICE=packit DEPLOYMENT=stg make download-secrets
+#
+# 2. Edit the secret file you want to update, for example:
+#
+#     $ $EDITOR secrets/packit/stg/packit-service.yaml
+#
+# 3. Update the secret in Bitwarden. For example:
+#
+#     $ ./scripts/update_bw_secret.sh secrets/packit/stg/packit-service.yaml
+#
+# The script figures out which Bitwarden item to edit from the path to the file,
+# so that needs to be provided as `secrets/<service>/<deployment>/<file>`.
+#
+# Nothing happens if the file did not change. The script also helps with
+# updating the `! Changelog !`: saves the note in a file, opens the file with
+# `$EDITOR` to be edited, and updates the note in Bitwarden.
+
+set -euo pipefail
+
+SECRET_FILE="${1:-}"
+SECRET_NAME=$(echo "$SECRET_FILE" | sed -E 's/^secrets\/(.+)\/(.+)\/(.+)$/secrets-\1-\2/')
+ATTACHMENT_NAME=$(echo "$SECRET_FILE" | sed -E 's/^secrets\/(.+)\/(.+)\/(.+)$/\3/')
+
+ARG_ERROR="Provide an argument in the form of 'secrets/<service>/<deployment>/<file>'!"
+test "$SECRET_FILE" != "$SECRET_NAME" || { echo "$ARG_ERROR"; exit 1; }
+test "$SECRET_FILE" != "$ATTACHMENT_NAME" || { echo "$ARG_ERROR"; exit 1; }
+test -f "$SECRET_FILE" || { echo "Secret file not found: $SECRET_FILE"; exit 1; }
+
+ITEM_ID=$(bw get item "$SECRET_NAME" | jq -r '.id')
+SECRET_NAME=$(bw get item "$SECRET_NAME" | jq -r '.name')
+ATTACHMENT_ID=$(bw get item "$ITEM_ID" | jq -r '.attachments[] | select(.fileName=="'${ATTACHMENT_NAME}'") | .id')
+
+test -n "$SECRET_NAME" || { echo "No secret name"; exit 1; }
+test -n "$ITEM_ID" || { echo "$SECRET_NAME has no ID"; exit 1; }
+test -n "$ATTACHMENT_ID" || { echo "Cannot find $ATTACHMENT_NAME"; exit 1; }
+
+rm -f "${SECRET_FILE}.old"
+# Make sure things are up-to-date. 'bw sync' updates the local 'bw' cache, not the files
+# already saved.
+bw sync
+bw get attachment --itemid "$ITEM_ID" --output "${SECRET_FILE}.old" "$ATTACHMENT_NAME" &> /dev/null
+
+if diff "${SECRET_FILE}.old" "$SECRET_FILE"; then
+    echo "Attachment '$ATTACHMENT_NAME' of '$SECRET_NAME' is the same as '$SECRET_FILE', skipping..."
+else
+    echo
+    read -p "Do you want to replace attachment '$ATTACHMENT_NAME' of '$SECRET_NAME' with '$SECRET_FILE'? [y/N] " -r
+    case $REPLY in
+        [Yy]* ) {
+            CHANGELOG_ID=$(bw get item "! Changelog !" | jq -r '.id')
+            # CHANGELOG_ID=$(bw get item "my-changelog" | jq -r '.id')
+            test -n "$CHANGELOG_ID" || { echo "Cannot tell changelog id."; exit 1; }
+            bw get item "$CHANGELOG_ID" | jq -r '.notes' > .secrets.changelog.old
+            if test -z "$(sed '/^null$/d' .secrets.changelog.old)"; then
+                echo "Failed to get changelog, aborting..."
+                exit 1
+            fi
+            cp .secrets.changelog.old .secrets.changelog
+            $EDITOR .secrets.changelog
+
+            bw delete attachment --itemid "$ITEM_ID" "$ATTACHMENT_ID" && echo "---> Attachment deleted"
+            bw create attachment --itemid "$ITEM_ID" --file "$SECRET_FILE" && echo -e "\n---> Attachment re-created"
+            bw get item "$CHANGELOG_ID" | jq ".notes=$(cat .secrets.changelog | jq -sR)" | bw encode | bw edit item "$CHANGELOG_ID"
+
+            rm -f .secrets.changelog .secrets.changelog.old
+        };;
+        * ) echo "Skipping..."; exit 0;;
+    esac
+
+fi
+
+rm -f "${SECRET_FILE}.old"

--- a/scripts/update_oc_secret.sh
+++ b/scripts/update_oc_secret.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+# This quick script updates a data field of an OpenShift secret with the
+# content of a file.
+#
+# The name of the data field is the basename of the file.
+#
+# Run as:
+#
+#     scripts/update_oc_secret.sh <secret_name> <path_to_file>
+#
+# For example:
+#
+#     scripts/update_oc_secret.sh packit-config secrets/packit/stg/packit-service.yaml
+#
+# It's up to you to log in to the right cluster and select the right namespace
+# to work on.
+
+set -euo pipefail
+
+DATA=$(basename $2)
+oc get secrets/$1 -o json | jq -r ".data.\"${DATA}\"=$(cat $2 | base64 -w0 | jq -sR)" | oc apply -f -

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -37,6 +37,48 @@ Nothing happens if the file did not change. The script also helps with
 updating the `! Changelog !`: saves the note in a file, opens the file with
 `$EDITOR` to be edited, and updates the note in Bitwarden.
 
+## Update secrets in OpenShift
+
+Use `scripts/update_oc_secret.sh` to update secrets directly in OpenShift from
+the command-line.
+
+1. First make sure the local copy of the secret you are updating is in sync
+   with the one stored in Bitwarden, so download the secrets for the service
+   and deployment you want to work on. For example:
+
+   ```
+   $ SERVICE=packit DEPLOYMENT=stg make download-secrets
+   ```
+
+2. Login to OpenShift and select the right project. For example:
+
+   ```
+   $ oc login ...
+   $ oc project packit-stg
+   ```
+
+3. Edit the secret file you want to update. For example:
+
+   ```
+   $ $EDITOR secrets/packit/stg/packit-service.yaml
+   ```
+
+4. Update the secret in OpenShift with the content of the file. You'll need to
+   know the name of the secret. For example:
+
+   ```
+   $ scripts/update_oc_secret.sh packit-config secrets/packit/stg/packit-service.yaml
+   ```
+
+5. Update the secret in Bitwarden. For example:
+
+   ```
+   $ scripts/update_bw_secret.sh secrets/packit/stg/packit-service.yaml
+   ```
+
+Don't forget that you'll need to re-spin the pods using the secret, so that
+they pick up the change.
+
 ## What secret files the deployment expects
 
 Not all services expect all of them. For example source-git services don't need `copr` & `private-key.pem`.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -1,9 +1,41 @@
-## Secrets
+# Secrets
 
 Deployment process (`make deploy`) expects files to be transformed to
 Openshift secrets to be found in these subdirectories.
 These files are either automatically downloaded (`make download-secrets`)
 or they need to be created manually in case of local/dev/test deployment.
+
+## Update secrets in Bitwarden
+
+Use `scripts/update_bw_secret.sh` to update secrets, and don't have to click
+through the Bitwarden Web UI, deleting and uploading attachments.
+
+Here is the workflow how to do that:
+
+1. Make sure your local copy is up to date. For example:
+
+   ```
+   $ SERVICE=packit DEPLOYMENT=stg make download-secrets
+   ```
+
+2. Edit the secret file you want to update, for example:
+
+   ```
+   $ $EDITOR secrets/packit/stg/packit-service.yaml
+   ```
+
+3. Update the secret in Bitwarden. For example:
+
+   ```
+   $ ./scripts/update_bw_secret.sh secrets/packit/stg/packit-service.yaml
+   ```
+
+The script figures out which Bitwarden item to edit from the path to the file,
+so that needs to be provided as `secrets/<service>/<deployment>/<file>`.
+
+Nothing happens if the file did not change. The script also helps with
+updating the `! Changelog !`: saves the note in a file, opens the file with
+`$EDITOR` to be edited, and updates the note in Bitwarden.
 
 ## What secret files the deployment expects
 


### PR DESCRIPTION
Updating the `allowed_forge_projects_for_copr_project` config in `packit-service.yaml` is quite tedious.

This PR adds two scripts and some documentation to make this easier and consistent. 