### PR TITLE
Generate empty flower-htpasswd in generate-secrets role

### DIFF
--- a/roles/generate-secrets/tasks/touch-files.yml
+++ b/roles/generate-secrets/tasks/touch-files.yml
@@ -10,3 +10,4 @@
   loop:
     - fedora.keytab
     - sentry_key
+    - flower-htpasswd


### PR DESCRIPTION
The deploy playbook creates the file on the fly
https://github.com/packit/deployment/blob/922774598e15195b6ff349d19d6b01c7b775654b/playbooks/deploy.yml#L362-L364)
but only when `with_flower` is `True`.
It is needed in https://github.com/packit/deployment/blob/922774598e15195b6ff349d19d6b01c7b775654b/playbooks/deploy.yml#L375 even when `with_flower` is `False`, [because it's in a loop](https://github.com/ansible/ansible/issues/64883#issuecomment-554403674).
So we have to make sure the file is always there.

Fixes
```
2022-06-28 16:46:09.630911 | test-node | TASK [Upload flower secret] ****************************************************
2022-06-28 16:46:09.630950 | test-node | task path: /home/zuul-worker/src/github.com/packit/deployment/playbooks/deploy.yml:372
2022-06-28 16:46:10.064393 | test-node | [WARNING]: Unable to find '/home/zuul-
2022-06-28 16:46:10.064498 | test-node | worker/src/github.com/packit/deployment/playbooks/../secrets/packit/dev/flower-
2022-06-28 16:46:10.064527 | test-node | htpasswd' in expected paths (use -vvvvv to see paths)
```