### PR TITLE
Don't use tasks/k8s.yml to deploy flower-htpasswd secret

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -368,9 +368,13 @@
             password: "{{ flower_basic_auth | regex_replace('flower-boss:', '') }}"
             mode: 0640
         - name: Deploy flower-htpasswd secret
-          include_tasks: tasks/k8s.yml
-          loop:
-            - "{{ lookup('template', '{{ project_dir }}/openshift/secret-flower-htpasswd.yml.j2') }}"
+          # Don't use tasks/k8s.yml here because the loop item is always evaluated
+          k8s:
+            namespace: "{{ project }}"
+            resource_definition: "{{ lookup('template', '{{ project_dir }}/openshift/secret-flower-htpasswd.yml.j2') }}"
+            host: "{{ host }}"
+            api_key: "{{ api_key }}"
+            validate_certs: "{{ validate_certs }}"
       tags:
         - flower
       when: with_flower

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -359,20 +359,18 @@
         - pushgateway
       when: with_pushgateway
 
-    - name: Create htpasswd file with flower-boss passwd
-      htpasswd:
-        path: "{{ flower_secret_htpasswd }}"
-        name: "flower-boss"
-        password: "{{ flower_basic_auth | regex_replace('flower-boss:', '') }}"
-        mode: 0640
-      tags:
-        - flower
-      when: with_flower
-
-    - name: Upload flower secret
-      include_tasks: tasks/k8s.yml
-      loop:
-        - "{{ lookup('template', '{{ project_dir }}/openshift/secret-flower-htpasswd.yml.j2') }}"
+    - name: Create htpasswd file and deploy it as a secret
+      block:
+        - name: Create htpasswd file
+          htpasswd:
+            path: "{{ flower_secret_htpasswd }}"
+            name: "flower-boss"
+            password: "{{ flower_basic_auth | regex_replace('flower-boss:', '') }}"
+            mode: 0640
+        - name: Deploy flower-htpasswd secret
+          include_tasks: tasks/k8s.yml
+          loop:
+            - "{{ lookup('template', '{{ project_dir }}/openshift/secret-flower-htpasswd.yml.j2') }}"
       tags:
         - flower
       when: with_flower

--- a/playbooks/tasks/k8s.yml
+++ b/playbooks/tasks/k8s.yml
@@ -2,8 +2,18 @@
 # SPDX-License-Identifier: MIT
 
 ---
-# https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
+# Usage:
+#   include_tasks: tasks/k8s.yml
+#   loop:
+#     - "{{ lookup('template', 'object.yml.j2') }}"
+#     - "{{ lookup('file', 'another.yml') }}"
+
+# Limitations:
+# - It doesn't work (reason unknown) together with a 'notify:'.
+# - If used with 'when:' condition the lookups are run even when the 'when:' resolves to False.
+#   https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#loops-and-conditionals
 - name: Create k8s object
+  # https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
   k8s:
     namespace: "{{ project }}"
     resource_definition: "{{ item }}"


### PR DESCRIPTION
Beside `notify` (https://github.com/packit/deployment/commit/492ccf419a5ff8d1da2b1901df71b16f1f37bd58) this is another use case when the [tasks/k8s.yml](https://github.com/packit/deployment/blob/main/playbooks/tasks/k8s.yml) can't be used.

The problem is that the loop item is ALWAYS evaluated even when the `when:` condition resolves to `False` (i.e. in this case when `with_flower` is `False`).
https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#loops-and-conditionals

When `with_flower` is `False`, the `htpasswd` file is not created in the previous task and the `secret-flower-htpasswd.yml.j2` template then fails to be processed.

```
2022-06-28 16:46:09.630911 | test-node | TASK [Upload flower secret] ****************************************************
2022-06-28 16:46:09.630950 | test-node | task path: /home/zuul-worker/src/github.com/packit/deployment/playbooks/deploy.yml:372
2022-06-28 16:46:10.064393 | test-node | [WARNING]: Unable to find '/home/zuul-
2022-06-28 16:46:10.064498 | test-node | worker/src/github.com/packit/deployment/playbooks/../secrets/packit/dev/flower-
2022-06-28 16:46:10.064527 | test-node | htpasswd' in expected paths (use -vvvvv to see paths)
```