### PR TITLE
Don't deploy a common worker on prod

### DIFF
--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -73,7 +73,7 @@ repository_cache_storage: 10Gi
 # celery_retry_backoff: 3
 
 # Number of worker pods to be deployed to serve the queues
-# workers_all_tasks: 1
+workers_all_tasks: 0
 workers_short_running: 4
 workers_long_running: 2
 # pushgateway_address: http://pushgateway


### PR DESCRIPTION
Since we introduced workers for the specific (long/short running) queues, we've been adding specific workers but still kept the one common.
558771f3 -> 4d7c6550 -> aebd8375 -> c2554b01 -> cdf6beba

Now we've agreed that we actually don't need the common one.