### PR TITLE
Remove python3-packaging from the base image

### DIFF
--- a/containers/Dockerfile.base
+++ b/containers/Dockerfile.base
@@ -13,5 +13,4 @@ RUN dnf update -y \
       # because ansible in F36 already contains the community collection
       ansible-collection-community-general \
       python3-pip \
-      python3-packaging \
     && dnf clean all

--- a/secrets/template/packit-service.yaml
+++ b/secrets/template/packit-service.yaml
@@ -26,9 +26,6 @@ command_handler_work_dir: /tmp/sandcastle
 command_handler_image_reference: quay.io/packit/sandcastle
 command_handler_k8s_namespace: packit-dev-sandbox
 
-bugzilla_url: <Bugzilla url>
-bugzilla_api_key: <Bugzilla API key>
-
 enabled_private_namespaces:
   - "https://github.com/secret-namespace"
   - "https://gitlab.com/secret/namespace"


### PR DESCRIPTION
It was added in 3ae73fab9 because of [setupcfg2rpm script](https://github.com/packit/deployment/blob/main/scripts/setupcfg2rpm.py), but the script has not been used in packit-service since https://github.com/packit/packit-service/pull/1616#pullrequestreview-1075113194
It's used only in [tokman](https://github.com/packit/tokman/blob/main/Containerfile#L18) but that image is based on fedora (and not this base image).

The removal of `bugzilla_*` keys is related to packit/packit-service#1621