### PR TITLE
changelog.py: get release notes from GitHub PRs

### DIFF
--- a/scripts/move_stable.py
+++ b/scripts/move_stable.py
@@ -300,7 +300,7 @@ def create_blogpost(
         git_repo = Repo(path_to_repository)
         main_hash = get_reference(path_to_repository, remote, ROLLING_BRANCH)[:7]
         commits = git_repo.iter_commits(main_hash, merges=True, since=git_since)
-        click.echo(changelog.get_changelog(commits, repo).rstrip())
+        click.echo(changelog.get_changelog(commits, repo, make_link=True).rstrip())
 
 
 def get_reference(path_to_repository: Path, remote: str, branch: str) -> str:


### PR DESCRIPTION
So that the formatting is preserved. GitHub strips Markdown in merge commits.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>
Co-authored-by: Laura Barcziová <lbarczio@redhat.com>
Co-authored-by: Nikola Forró <nforro@redhat.com>
Co-authored-by: František Lachman <flachman@redhat.com>
Co-authored-by: Maja Massarini <mmassari@redhat.com>
Co-authored-by: Matěj Focko <mfocko@redhat.com>
Co-authored-by: Tomáš Tomeček <ttomecek@redhat.com>