### PR TITLE
Use Deployments instead of DeploymentConfigs

### DIFF
--- a/docs/continuous-deployment.md
+++ b/docs/continuous-deployment.md
@@ -8,9 +8,9 @@ as intermediary between an image registry (Quay.io) and a Deployment/StatefulSet
 It has several significant benefits:
 
 - We can automatically trigger Deployment when a new image is pushed to the registry.
-- We can rollback/revert/undo the Deployment.
+- We can roll back/revert/undo the Deployment.
 
-`Image registry` -> [1] -> `ImageStream` -> `DeploymentConfig`/`StatefulSet`
+`Image registry` -> [1] -> `ImageStream` -> `Deployment`/`StatefulSet`
 
 [1] This is automatic (even it can take some time) on stg, but not on prod.
 On prod, where we don't want the images to
@@ -46,13 +46,13 @@ There's also 'import-images' target in the Makefile, so `DEPLOYMENT=prod make im
 
 ### Reverting to older deployment/revision/image
 
-`DeploymentConfig`s can be reverted with `oc rollout undo`:
+`Deployment`s can be reverted with `oc rollout undo`:
 
-    $ oc rollout undo dc/packit-service [--to-revision=X]
-    $ oc rollout undo dc/packit-service-fedmsg [--to-revision=X]
+    $ oc rollout undo deploy/packit-service [--to-revision=X]
+    $ oc rollout undo deploy/packit-service-fedmsg [--to-revision=X]
 
 where `X` is revision number.
-See also `oc rollout history dc/packit-service [--revision=X]`.
+See also `oc rollout history deploy/packit-service [--revision=X]`.
 
 It's more tricky in case of `StatefulSet` which we use for workers.
 `oc rollout undo` does not seem to work with `StatefulSet`

--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -6,6 +6,10 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: packit-dashboard
+  annotations:
+    # https://docs.openshift.com/container-platform/4.11/openshift_images/triggering-updates-on-imagestream-changes.html
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"packit-dashboard:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"packit-dashboard\")].image"}]
 spec:
   selector:
     matchLabels:
@@ -39,17 +43,6 @@ spec:
         - name: packit-secrets
           secret:
             secretName: packit-secrets
-
-  triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - packit-dashboard
-        from:
-          kind: ImageStreamTag
-          name: packit-dashboard:{{ deployment }}
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -6,16 +6,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: packit-dashboard
-  labels:
-    service: packit-dashboard
 spec:
   selector:
-    service: packit-dashboard
+    matchLabels:
+      component: packit-dashboard
   template:
     metadata:
       labels:
-        service: packit-dashboard
-        name: packit-dashboard
+        component: packit-dashboard
     spec:
       containers:
         - name: packit-dashboard
@@ -60,15 +58,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: packit-dashboard
-  labels:
-    service: packit-dashboard
 spec:
   ports:
     - name: packit-dashboard-https
       port: 443
       targetPort: 8443
   selector:
-    service: packit-dashboard
+    component: packit-dashboard
 ---
 kind: Route
 apiVersion: route.openshift.io/v1

--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: packit-dashboard
   labels:

--- a/openshift/flower.yml
+++ b/openshift/flower.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: flower
   labels:

--- a/openshift/flower.yml
+++ b/openshift/flower.yml
@@ -6,16 +6,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: flower
-  labels:
-    service: flower
 spec:
   selector:
-    service: flower
+    matchLabels:
+      component: flower
   template:
     metadata:
       labels:
-        service: flower
-        name: flower
+        component: flower
     spec:
       containers:
         - name: flower
@@ -42,12 +40,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flower
-  labels:
-    service: flower
 spec:
   ports:
     - name: "5555"
       port: 5555
       targetPort: 5555
   selector:
-    service: flower
+    component: flower

--- a/openshift/nginx.yml.j2
+++ b/openshift/nginx.yml.j2
@@ -1,8 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: nginx
   labels:

--- a/openshift/nginx.yml.j2
+++ b/openshift/nginx.yml.j2
@@ -6,16 +6,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: nginx
-  labels:
-    service: nginx
 spec:
   selector:
-    service: nginx
+    matchLabels:
+      component: nginx
   template:
     metadata:
       labels:
-        service: nginx
-        name: nginx
+        component: nginx
     spec:
       volumes:
       - name: nginx-config
@@ -102,8 +100,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx
-  labels:
-    service: nginx
 spec:
   ports:
     - name: nginx-https
@@ -111,14 +107,12 @@ spec:
       protocol: TCP
       targetPort: 8443
   selector:
-    service: nginx
+    component: nginx
 ---
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: nginx
-  labels:
-    service: nginx
 spec:
   host: "{{ 'workers.stg.packit.dev' if deployment == 'stg' else 'workers.packit.dev' if deployment == 'prod'}}"
   port:

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   labels:
     app: packit

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -5,16 +5,15 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  labels:
-    app: packit
-    name: packit-service-beat
   name: packit-service-beat
 spec:
+  selector:
+    matchLabels:
+      component: packit-service-beat
   template:
     metadata:
       labels:
-        name: packit-service-beat
-        app: packit
+        component: packit-service-beat
     spec:
       volumes:
         - name: packit-ssh

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -6,6 +6,10 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: packit-service-beat
+  annotations:
+    # https://docs.openshift.com/container-platform/4.11/openshift_images/triggering-updates-on-imagestream-changes.html
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"packit-worker:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"packit-service-beat\")].image"}]
 spec:
   selector:
     matchLabels:
@@ -67,16 +71,6 @@ spec:
             limits:
               memory: "150Mi"
               cpu: "10m"
-  triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - packit-service-beat
-        from:
-          kind: ImageStreamTag
-          name: packit-worker:{{ deployment }}
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -5,16 +5,15 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  labels:
-    app: packit
-    name: packit-service-fedmsg
   name: packit-service-fedmsg
 spec:
+  selector:
+    matchLabels:
+      component: packit-service-fedmsg
   template:
     metadata:
       labels:
-        name: packit-service-fedmsg
-        app: packit
+        component: packit-service-fedmsg
     spec:
       volumes:
         - name: packit-config

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -1,9 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-# https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/how_deployments_work.html
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+---
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   labels:
     app: packit

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -6,6 +6,10 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: packit-service-fedmsg
+  annotations:
+    # https://docs.openshift.com/container-platform/4.11/openshift_images/triggering-updates-on-imagestream-changes.html
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"packit-service-fedmsg:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"packit-service-fedmsg\")].image"}]
 spec:
   selector:
     matchLabels:
@@ -42,16 +46,6 @@ spec:
             limits:
               memory: "80Mi"
               cpu: "20m"
-  triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - packit-service-fedmsg
-        from:
-          kind: ImageStreamTag
-          name: packit-service-fedmsg:{{ deployment }}
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -5,16 +5,15 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  labels:
-    app: packit
-    name: packit-service
   name: packit-service
 spec:
+  selector:
+    matchLabels:
+      component: packit-service
   template:
     metadata:
       labels:
-        name: packit-service
-        app: packit
+        component: packit-service
     spec:
       volumes:
         - name: packit-secrets
@@ -107,21 +106,17 @@ kind: Service
 metadata:
   name: packit-service
 spec:
-  selector:
-    name: packit-service
-    app: packit
   ports:
     - name: prod-packit
       port: 443
       protocol: TCP
       targetPort: 8443
+  selector:
+    component: packit-service
 ---
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  labels:
-    app: packit
-    name: packit-service
   name: packit-service
 spec:
 # for local deployment (dev) creates default route for testing.

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -1,9 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-# https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/how_deployments_work.html
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+---
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   labels:
     app: packit

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -6,6 +6,10 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: packit-service
+  annotations:
+    # https://docs.openshift.com/container-platform/4.11/openshift_images/triggering-updates-on-imagestream-changes.html
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"packit-service:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"packit-service\")].image"}]
 spec:
   selector:
     matchLabels:
@@ -87,16 +91,6 @@ spec:
           #     scheme: HTTPS
           #     path: /api/healthz/
           #   initialDelaySeconds: 30
-  triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - packit-service
-        from:
-          kind: ImageStreamTag
-          name: packit-service:{{ deployment }}
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -8,9 +8,7 @@ apiVersion: apps/v1
 metadata:
   name: {{ name }}
   annotations:
-    # Setting triggers to StatefulSet is tricky (they also don't appear in GUI).
-    # I run the following and then checked how the resulting yaml looks like.
-    # oc set triggers statefulset.apps/packit-worker --from-image=packit-worker:dev -c packit-worker
+    # https://docs.openshift.com/container-platform/4.11/openshift_images/triggering-updates-on-imagestream-changes.html
     image.openshift.io/triggers: >-
       [{"from":{"kind":"ImageStreamTag","name":"packit-worker:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"packit-worker\")].image"}]
 spec:

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -17,8 +17,7 @@ spec:
   selector:
     matchLabels:
       # has to match .spec.template.metadata.labels
-      name: {{ name }}
-      app: packit
+      component: {{ name }}
   serviceName: "{{ name }}"
   replicas: {{ worker_replicas }}
   volumeClaimTemplates:
@@ -39,8 +38,7 @@ spec:
   template:
     metadata:
       labels:
-        name: {{ name }}
-        app: packit
+        component: {{ name }}
       # https://docs.openshift.com/container-platform/latest/openshift_images/using-imagestreams-with-kube-resources.html
       annotations:
         alpha.image.policy.openshift.io/resolve-names: '*'

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: postgres-13
   labels:

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -6,19 +6,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: postgres-13
-  labels:
-    service: postgres-13
 spec:
-  replicas: 1
-  strategy:
-    type: Recreate
   selector:
-    service: postgres-13
+    matchLabels:
+      component: postgres-13
   template:
     metadata:
       labels:
-        service: postgres-13
-        name: postgres-13
+        component: postgres-13
     spec:
       containers:
         - name: postgres
@@ -81,6 +76,9 @@ spec:
         - name: postgres-config
           configMap:
             name: postgres-config
+  replicas: 1
+  strategy:
+    type: Recreate
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -108,7 +106,7 @@ spec:
       port: 5432
       targetPort: 5432
   selector:
-    service: postgres-13
+    component: postgres-13
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -1,8 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   labels:
     app: packit

--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -5,16 +5,15 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  labels:
-    app: packit
-    name: pushgateway
   name: pushgateway
 spec:
+  selector:
+    matchLabels:
+      component: pushgateway
   template:
     metadata:
       labels:
-        name: pushgateway
-        app: packit
+        component: pushgateway
     spec:
       containers:
         - name: pushgateway
@@ -42,11 +41,10 @@ kind: Service
 metadata:
   name: pushgateway
 spec:
-  selector:
-    name: pushgateway
-    app: packit
   ports:
     - name: prometheus-push
       port: 80
       protocol: TCP
       targetPort: 9091
+  selector:
+    component: pushgateway

--- a/openshift/redis-commander.yml
+++ b/openshift/redis-commander.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: redis-commander
   labels:

--- a/openshift/redis-commander.yml
+++ b/openshift/redis-commander.yml
@@ -6,16 +6,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: redis-commander
-  labels:
-    service: redis-commander
 spec:
   selector:
-    service: redis-commander
+    matchLabels:
+      component: redis-commander
   template:
     metadata:
       labels:
-        service: redis-commander
-        name: redis-commander
+        component: redis-commander
     spec:
       containers:
         - name: redis-commander
@@ -53,15 +51,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-commander
-  labels:
-    service: redis-commander
 spec:
   ports:
     - name: "8081"
       port: 8081
       targetPort: 8081
   selector:
-    service: redis-commander
+    component: redis-commander
 ---
 kind: Route
 apiVersion: route.openshift.io/v1

--- a/openshift/redis.yml
+++ b/openshift/redis.yml
@@ -1,8 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+
 ---
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: redis
   labels:

--- a/openshift/redis.yml
+++ b/openshift/redis.yml
@@ -6,16 +6,14 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: redis
-  labels:
-    service: redis
 spec:
   selector:
-    service: redis
+    matchLabels:
+      component: redis
   template:
     metadata:
       labels:
-        service: redis
-        name: redis
+        component: redis
     spec:
       containers:
         - name: redis
@@ -51,7 +49,7 @@ spec:
       port: 6379
       targetPort: 6379
   selector:
-    service: redis
+    component: redis
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -6,6 +6,10 @@ kind: Deployment
 apiVersion: apps/v1
 metadata:
   name: tokman
+  annotations:
+    # https://docs.openshift.com/container-platform/4.11/openshift_images/triggering-updates-on-imagestream-changes.html
+    image.openshift.io/triggers: >-
+      [{"from":{"kind":"ImageStreamTag","name":"tokman:{{ deployment }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"tokman\")].image"}]
 spec:
   selector:
     matchLabels:
@@ -73,16 +77,6 @@ spec:
               port: 8000
             timeoutSeconds: 2
             periodSeconds: 20
-  triggers:
-    - type: ConfigChange
-    - type: ImageChange
-      imageChangeParams:
-        automatic: true
-        containerNames:
-          - tokman
-        from:
-          kind: ImageStreamTag
-          name: tokman:{{ deployment }}
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -1,9 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-# https://docs.openshift.com/container-platform/3.11/dev_guide/deployments/how_deployments_work.html
-kind: DeploymentConfig
-apiVersion: apps.openshift.io/v1
+---
+kind: Deployment
+apiVersion: apps/v1
 metadata:
   labels:
     app: packit

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -5,16 +5,15 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  labels:
-    app: packit
-    name: tokman
   name: tokman
 spec:
+  selector:
+    matchLabels:
+      component: tokman
   template:
     metadata:
       labels:
-        name: tokman
-        app: packit
+        component: tokman
     spec:
       volumes:
         - name: github-app-private-key
@@ -122,14 +121,13 @@ kind: Service
 metadata:
   name: tokman
 spec:
-  selector:
-    name: tokman
-    app: packit
   ports:
     - name: tokman
       port: 80
       protocol: TCP
       targetPort: 8000
+  selector:
+    component: tokman
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -391,7 +391,7 @@
 
     - name: Wait for deploymentconfig rollouts to complete
       # timeout 10min to not wait indefinitely in case of a problem
-      ansible.builtin.command: timeout 10m oc rollout status -w dc/{{ item }}
+      ansible.builtin.command: timeout 10m oc rollout status -w deploy/{{ item }}
       register: oc_rollout_status
       changed_when: false
       failed_when: '"successfully rolled out" not in oc_rollout_status.stdout'
@@ -399,19 +399,19 @@
 
   handlers:
     - name: Rollout redis-commander
-      ansible.builtin.command: oc rollout latest dc/redis-commander
+      ansible.builtin.command: oc rollout latest deploy/redis-commander
       # Run this rollout only if the DeploymentConfig above didn't change,
       # and so it wasn't rolled out yet.
       when: not redis_commander.changed
 
     - name: Rollout tokman
-      ansible.builtin.command: oc rollout latest dc/tokman
+      ansible.builtin.command: oc rollout latest deploy/tokman
       # Run this rollout only if the DeploymentConfig above didn't change,
       # and so it wasn't rolled out yet.
       when: not tokman.changed
 
     - name: Rollout flower
-      ansible.builtin.command: oc rollout latest dc/flower
+      ansible.builtin.command: oc rollout latest deploy/flower
       # Run this rollout only if the DeploymentConfig above didn't change,
       # and so it wasn't rolled out yet.
       when: not flower.changed

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -398,20 +398,20 @@
       loop: "{{ deploymentconfigs }}"
 
   handlers:
-    - name: Rollout redis-commander
-      ansible.builtin.command: oc rollout latest deploy/redis-commander
+    - name: Restart redis-commander deployment
+      ansible.builtin.command: oc rollout restart deploy/redis-commander
       # Run this rollout only if the DeploymentConfig above didn't change,
       # and so it wasn't rolled out yet.
       when: not redis_commander.changed
 
-    - name: Rollout tokman
-      ansible.builtin.command: oc rollout latest deploy/tokman
+    - name: Restart tokman deployment
+      ansible.builtin.command: oc rollout restart deploy/tokman
       # Run this rollout only if the DeploymentConfig above didn't change,
       # and so it wasn't rolled out yet.
       when: not tokman.changed
 
-    - name: Rollout flower
-      ansible.builtin.command: oc rollout latest deploy/flower
+    - name: Restart flower deployment
+      ansible.builtin.command: oc rollout restart deploy/flower
       # Run this rollout only if the DeploymentConfig above didn't change,
       # and so it wasn't rolled out yet.
       when: not flower.changed


### PR DESCRIPTION
OpenShift introduced `DeploymentConfig` objects before `Deployments` were added to upstream Kubernetes.
[Deployments are now in general preferred in OCP 4](https://docs.openshift.com/container-platform/4.11/applications/deployments/what-deployments-are.html#deployments-comparing-deploymentconfigs_what-deployments-are).

For me personally, the benefit would be that:
- I could see Metrics for the Deployment without having to go to Pods first
- the *-deploy pods would no longer (as I understand it) clutter the list of all (project's) pods