### PR TITLE
Add `render-secrets-from-templates` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ TAGS ?= all
 download-secrets:
 	./scripts/download_secrets.sh
 
+# Mimic what we do during deployment when we render secret files
+# from their templates before we create k8s secrets from them.
+render-secrets-from-templates:
+	./scripts/render_secrets_from_templates.sh
+
 # If you're sure you want to skip the secrets downloading,
 # because for example you just did it and you don't want to wait for it again
 # just set SKIP_SECRETS_SYNC or SSS to any value.

--- a/docs/allow-custom-copr-projects.md
+++ b/docs/allow-custom-copr-projects.md
@@ -1,6 +1,6 @@
 # Configure projects to be built in custom Copr repositories
 
-By default Packit builds PRs in it's own namespace in Copr. It's possible
+By default, Packit builds PRs in its own namespace in Copr. It's possible
 though to configure it to use a dedicated Copr repository by setting a
 `project` and an `owner` config value.
 
@@ -40,10 +40,10 @@ sure you are doing everything right.
    $ SERVICE=packit DEPLOYMENT=stg make download-secrets
    ```
 
-2. Edit `packit-service.yaml` and add the new mapping.
+2. Edit `packit-service.yaml.j2` and add the new mapping.
 
    ```
-   $ $EDITOR secrets/packit/stg/packit-service.yaml
+   $ $EDITOR secrets/packit/stg/packit-service.yaml.j2
    ```
 
    In case of group owned Copr repos the change is going to look like this:
@@ -66,7 +66,13 @@ sure you are doing everything right.
    There can be multiple GitHub projects allowed to be built in the same Copr
    repo.
 
-   Test that `packit-service.yaml` is a valid YAML. Use Python or
+   Render `packit-service.yaml` from the template:
+
+   ```shell
+   $ SERVICE=packit DEPLOYMENT=stg make render-secrets-from-templates
+   ```
+
+   Test that it is a valid YAML. Use Python or
    [yq](https://github.com/mikefarah/yq) for this.
 
 3. Login to the stage cluster and select the stage namespace:
@@ -82,13 +88,7 @@ sure you are doing everything right.
    $ scripts/update_oc_secret.sh packit-config secrets/packit/stg/packit-service.yaml
    ```
 
-5. Save the new config to Bitwarden:
-
-   ```
-   $ scripts/update_bw_secret.sh secrets/packit/stg/packit-service.yaml
-   ```
-
-6. Respin all the worker pods to pick up the change, by first scaling the
+5. Re-spin all the worker pods to pick up the change, by first scaling the
    stateful sets to 0 replicas, and then scaling them back to the original
    number.
 
@@ -106,9 +106,8 @@ sure you are doing everything right.
 
 This is the same as doing it in stage, just replace `stg` with `prod`.
 
-In prod there might be more types of workers (`packit-worker`,
-`packit-worker-short-running`, `packit-worker-long-running`). All of them
-need to be respinned.
+In prod there might be more types of workers (`packit-worker-short-running`,
+`packit-worker-long-running`). All of them need to be respinned.
 
 ## 4. Let the user know that the change was made
 

--- a/playbooks/render_secrets_from_templates.yml
+++ b/playbooks/render_secrets_from_templates.yml
@@ -1,0 +1,22 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+# Mimic what we do during deployment when we render secret files
+# from their templates before we create k8s secrets from them.
+---
+- name: Process templates with data from extra-vars.yml
+  hosts: all
+  tasks:
+    - name: include extra secret vars
+      ansible.builtin.include_vars:
+        file: "{{ path_to_secrets }}/extra-vars.yml"
+        name: vault
+
+    - name: Process template
+      ansible.builtin.template:
+        src: "{{ path_to_secrets }}/{{ item }}.j2"
+        dest: "{{ path_to_secrets }}/{{ item }}"
+        mode: "0644"
+      loop:
+        - packit-service.yaml
+        - fedora.toml

--- a/scripts/render_secrets_from_templates.sh
+++ b/scripts/render_secrets_from_templates.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+
+# Mimic what we do during deployment when we render secret files
+# from their templates before we create k8s secrets from them.
+
+set -euo pipefail
+
+# Set default values if not set already
+: "${SERVICE:=packit}"
+: "${DEPLOYMENT:=dev}"
+
+# Where to process the files
+DEFAULT_PATH_TO_SECRETS="secrets/${SERVICE}/${DEPLOYMENT}/"
+: "${PATH_TO_SECRETS:=$DEFAULT_PATH_TO_SECRETS}"
+
+ansible-playbook -v -c local -i localhost, -e path_to_secrets=$(realpath "${PATH_TO_SECRETS}") playbooks/render_secrets_from_templates.yml

--- a/scripts/update_bw_secret.sh
+++ b/scripts/update_bw_secret.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-# Script to update the attachement of a secret item in Bitwarden
+# Script to update the attachment of a secret item in Bitwarden
 #
 # Here is the workflow how to do that:
 #

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -5,6 +5,8 @@ into one of the subdirectories and transformed into Kubernetes/Openshift secrets
 They can also be downloaded independently with `make download-secrets`.
 By default, these subdirectories contain only templates, which don't contain any secret,
 but which are processes and injected with secrets during the deployment process.
+If you want to see them rendered before you run the deployment,
+use `make render-secrets-from-templates`.
 
 ## Update secrets in Bitwarden
 
@@ -22,13 +24,13 @@ Here is the workflow how to do that:
 2. Edit the secret file you want to update, for example:
 
    ```
-   $ $EDITOR secrets/packit/stg/packit-service.yaml
+   $ $EDITOR secrets/packit/stg/extra-vars.yml
    ```
 
 3. Update the secret in Bitwarden. For example:
 
    ```
-   $ ./scripts/update_bw_secret.sh secrets/packit/stg/packit-service.yaml
+   $ ./scripts/update_bw_secret.sh secrets/packit/stg/extra-vars.yml
    ```
 
 The script figures out which Bitwarden item to edit from the path to the file,
@@ -43,38 +45,41 @@ updating the `! Changelog !`: saves the note in a file, opens the file with
 Use `scripts/update_oc_secret.sh` to update secrets directly in OpenShift from
 the command-line.
 
-1. First make sure the local copy of the secret you are updating is in sync
-   with the one stored in Bitwarden, so download the secrets for the service
-   and deployment you want to work on. For example:
+1. First make sure the local copies of the secrets are in sync
+   with what's stored in Bitwarden. For example:
 
    ```
    $ SERVICE=packit DEPLOYMENT=stg make download-secrets
    ```
 
-2. Login to OpenShift and select the right project. For example:
+2. Edit the file you want to update. For example:
+
+   ```
+   $ $EDITOR secrets/packit/stg/packit-service.yaml.j2
+   ```
+
+3. Render secret files from the templates:
+
+   ```
+   $ SERVICE=packit DEPLOYMENT=stg make render-secrets-from-templates
+   ```
+
+   This creates `packit-service.yaml` from `packit-service.yaml.j2`
+   (no secret values, stored in public repo) and `extra-vars.yml`
+   (secret values, downloaded from the vault).
+
+4. Login to OpenShift and select the right project. For example:
 
    ```
    $ oc login ...
    $ oc project packit-stg
    ```
 
-3. Edit the secret file you want to update. For example:
-
-   ```
-   $ $EDITOR secrets/packit/stg/packit-service.yaml
-   ```
-
-4. Update the secret in OpenShift with the content of the file. You'll need to
+5. Update the secret in OpenShift with the content of the file. You'll need to
    know the name of the secret. For example:
 
    ```
    $ scripts/update_oc_secret.sh packit-config secrets/packit/stg/packit-service.yaml
-   ```
-
-5. Update the secret in Bitwarden. For example:
-
-   ```
-   $ scripts/update_bw_secret.sh secrets/packit/stg/packit-service.yaml
    ```
 
 Don't forget that you'll need to re-spin the pods using the secret, so that


### PR DESCRIPTION
You need it if you want to create `packit-service.yaml` in order to run
`$ scripts/update_oc_secret.sh packit-config secrets/packit/stg/packit-service.yaml`

I've been thinking about whether to call it directly after downloading the secrets from the vault, but I'm leaving it separated so that people are aware that it's generated and not downloaded from the vault.

Also, it's not needed during the deployment so it'd slow it down.