### PR TITLE
Disable OpenSSL system configs when downloading secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=
 TAGS ?= all
 
 download-secrets:
-	./scripts/download_secrets.sh
+	# Disable the system configuration for OpenSSL, so that older,
+	# deprecated algorithms can be used by Bitwarden CLI.
+	# TODO: Remove this, once the issue below is resolved.
+	# https://github.com/bitwarden/clients/issues/2726#issuecomment-1292153245
+	OPENSSL_CONF= ./scripts/download_secrets.sh
 
 # Mimic what we do during deployment when we render secret files
 # from their templates before we create k8s secrets from them.

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -13,6 +13,14 @@ use `make render-secrets-from-templates`.
 Use `scripts/update_bw_secret.sh` to update secrets, and don't have to click
 through the Bitwarden Web UI, deleting and uploading attachments.
 
+Due to an [issue with Bitwarden
+CLI](https://github.com/bitwarden/clients/issues/2726), set `OPENSSL_CONF` as
+an empty variable if using Fedora Linux, in order to allow older, deprecated
+cryptographic algorithms to be used. Without this
+`scripts/update_bw_secret.sh` will not work.
+
+    $ export OPENSSL_CONF=
+
 Here is the workflow how to do that:
 
 1. Make sure your local copy is up-to-date. For example:


### PR DESCRIPTION
So that Bitwarden CLI can use older algorithms.

Resolves #329.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>