### PR TITLE
Increase postgres resources 1->1.5Gi

### DIFF
--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -36,7 +36,7 @@ spec:
               value: "/proc/self/oom_score_adj"
             # https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-SHARED-BUFFERS
             - name: POSTGRESQL_SHARED_BUFFERS
-              value: "{{ '200MB' if project == 'packit-prod' else '32MB' }}"
+              value: "{{ '242MB' if project == 'packit-prod' else '32MB' }}"
           ports:
             - containerPort: 5432
               protocol: TCP
@@ -62,10 +62,10 @@ spec:
           resources:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "{{ '1Gi' if project == 'packit-prod' else '128Mi' }}"
+              memory: "{{ '1.5Gi' if project == 'packit-prod' else '128Mi' }}"
               cpu: "{{ '300m' if project == 'packit-prod' else '100m' }}"
             limits:
-              memory: "{{ '1Gi' if project == 'packit-prod' else '128Mi' }}"
+              memory: "{{ '1.5Gi' if project == 'packit-prod' else '128Mi' }}"
               cpu: "{{ '300m' if project == 'packit-prod' else '100m' }}"
           volumeMounts:
             - name: postgres-data


### PR DESCRIPTION
Last time (2f07b2318) we tried to lower the value of shared buffers but it hasn't helped much so it's probably time to request more memory. The shared buffers value is 15% of the request/limit.
![Screenshot from 2022-11-08 17-54-52](https://user-images.githubusercontent.com/288686/200892024-ab90344c-5278-4698-a8c2-846bf0712b6d.png)
