### PR TITLE
One 16-threaded short-running worker @ prod

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -95,6 +95,10 @@ spec:
               valueFrom: {secretKeyRef: {name: aws, key: access-key-id}}
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom: {secretKeyRef: {name: aws, key: secret-access-key}}
+{% if queues == 'short-running' %}
+            - name: CONCURRENCY
+              value: "16"
+{% endif %}
             - name: SYSLOG_HOST
               # localhost doesn't work
               value: "127.0.0.1"

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -79,6 +79,6 @@ with_fluentd_sidecar: true
 
 # Number of worker pods to be deployed to serve the queues
 workers_all_tasks: 0
-workers_short_running: 4
+workers_short_running: 1
 workers_long_running: 2
 # pushgateway_address: http://pushgateway


### PR DESCRIPTION
kinda reverts 7b074a7ae but don't specify `POOL` because of packit/packit-service#1770

I'll merge next week once packit/packit-service#1770 is in stable/prod.