### PR TITLE
Adjust resource limits based on prod metrics

### DIFF
--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -33,10 +33,10 @@ spec:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "128Mi"
-              cpu: "100m"
+              cpu: "20m"
             limits:
               memory: "128Mi"
-              cpu: "100m"
+              cpu: "20m"
       volumes:
         - name: packit-secrets
           secret:

--- a/openshift/flower.yml
+++ b/openshift/flower.yml
@@ -30,10 +30,10 @@ spec:
           resources:
             requests:
               memory: "80Mi"
-              cpu: "50m"
+              cpu: "20m"
             limits:
               memory: "80Mi"
-              cpu: "50m"
+              cpu: "20m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/nginx.yml.j2
+++ b/openshift/nginx.yml.j2
@@ -44,11 +44,11 @@ spec:
         resources:
           # requests and limits have to be the same to have Guaranteed QoS
           requests:
-            memory: "80Mi"
-            cpu: "50m"
+            memory: "32Mi"
+            cpu: "10m"
           limits:
-            memory: "80Mi"
-            cpu: "50m"
+            memory: "32Mi"
+            cpu: "10m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -64,10 +64,10 @@ spec:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "150Mi"
-              cpu: "80m"
+              cpu: "10m"
             limits:
               memory: "150Mi"
-              cpu: "80m"
+              cpu: "10m"
   triggers:
     - type: ConfigChange
     - type: ImageChange

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -39,10 +39,10 @@ spec:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "80Mi"
-              cpu: "100m"
+              cpu: "20m"
             limits:
               memory: "80Mi"
-              cpu: "100m"
+              cpu: "20m"
   triggers:
     - type: ConfigChange
     - type: ImageChange

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -61,7 +61,7 @@ spec:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "320Mi"
-              cpu: "200m"
+              cpu: "{{ '200m' if project == 'packit-prod' else '100m' }}"
             limits:
               # run_httpd.sh does 'alembic upgrade head' which might require more memory
               # If you see '/usr/bin/run_httpd.sh: line 16:   Killed     alembic upgrade head'
@@ -69,7 +69,7 @@ spec:
               # (2Gi@prod, 512Mi@stg was enough last time),
               # and once the alembic upgrade passes, revert.
               memory: "320Mi"
-              cpu: "200m"
+              cpu: "{{ '200m' if project == 'packit-prod' else '100m' }}"
           # In TLS world, hostname needs to match whatever is set in the cert
           # in our cause, k8s is doing here something like curl https://172.15.2.4:8443/api/healthz/
           # which will fail TLS validation.

--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -26,11 +26,11 @@ spec:
           resources:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "80Mi"
-              cpu: "50m"
+              memory: "32Mi"
+              cpu: "10m"
             limits:
-              memory: "80Mi"
-              cpu: "50m"
+              memory: "32Mi"
+              cpu: "10m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/redis-commander.yml
+++ b/openshift/redis-commander.yml
@@ -40,11 +40,11 @@ spec:
           resources:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "80Mi"
-              cpu: "50m"
+              memory: "32Mi"
+              cpu: "10m"
             limits:
-              memory: "80Mi"
-              cpu: "50m"
+              memory: "32Mi"
+              cpu: "10m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/redis.yml
+++ b/openshift/redis.yml
@@ -27,11 +27,11 @@ spec:
           resources:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "80Mi"
-              cpu: "30m"
+              memory: "32Mi"
+              cpu: "10m"
             limits:
-              memory: "80Mi"
-              cpu: "30m"
+              memory: "32Mi"
+              cpu: "10m"
       volumes:
         - name: redis-pv
           persistentVolumeClaim:

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -55,10 +55,10 @@ spec:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "80Mi"
-              cpu: "100m"
+              cpu: "30m"
             limits:
               memory: "80Mi"
-              cpu: "100m"
+              cpu: "30m"
           ports:
             - containerPort: 8000
               protocol: "TCP"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -194,12 +194,10 @@
         name: packit-worker
         queues: "short-running,long-running"
         worker_replicas: "{{ workers_all_tasks }}"
-        # cloning repos is memory intensive: glibc needs 300M+, kernel 600M+
-        # during cloning, we need to account for git and celery worker processes
         worker_requests_memory: "384Mi"
-        worker_requests_cpu: "100m"
-        worker_limits_memory: "1024Mi"
-        worker_limits_cpu: "400m"
+        worker_requests_cpu: "20m"
+        worker_limits_memory: "384Mi"
+        worker_limits_cpu: "20m"
       ansible.builtin.include_tasks: tasks/k8s.yml
       loop:
         - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"


### PR DESCRIPTION
Looking at packit prod resource utilization graphs, one can see that we're requesting 1.4cpu, but utilizing 0.1-0.4cpu, so we're too greedy.

I went through packit-prod metrics for individual components for the past 2 weeks and adjusted the resource limits to be 2-3x the values at peaks so we should still be safe.

You can see that it's mostly adjusting cpu, but in some cases, it decreases the memory limit from 80Mi to 32Mi.
Those are components that need only a few MiB of memory but previously had the limit set to 80Mi because of Openshift Online where the limit couldn't be less than 80Mi, see 746cf271692

I already deployed this to `packit-stg` so you can check that everything works as expected.