### PR TITLE
Use environment files instead of set-output command

### DIFF
--- a/.github/workflows/base-image-rebuild.yml
+++ b/.github/workflows/base-image-rebuild.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build Image
         id: build-image

--- a/.github/workflows/build-and-push-cronjob-image.yml
+++ b/.github/workflows/build-and-push-cronjob-image.yml
@@ -26,13 +26,12 @@ jobs:
       path: cron-jobs/${{ matrix.image }}/
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
       - name: Add short SHA to the list of tags
         shell: bash
         run: |
-          echo "::set-output name=tags::latest ${GITHUB_SHA::7}"
+          echo "tags=latest ${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
         id: calculate-tags
 
       - name: Build Image


### PR DESCRIPTION
Related to #396

* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter