### PR TITLE
fix(import): add fluentd sidecar to image streams

### DIFF
--- a/playbooks/import-images.yml
+++ b/playbooks/import-images.yml
@@ -10,6 +10,7 @@
     with_fedmsg: true
     with_dashboard: true
     with_tokman: true
+    with_fluentd_sidecar: true
   tasks:
     - name: Include variables
       ansible.builtin.include_vars: ../vars/{{ service }}/{{ deployment }}.yml
@@ -18,6 +19,11 @@
       ansible.builtin.command: oc login {{ host }} --token={{ api_key }} --insecure-skip-tls-verify
       # it doesn't change anything, so don't report 'changed'
       changed_when: false
+
+    - name: Check/import newer fluentd image into image stream
+      ansible.builtin.command: oc import-image is/fluentd:{{ deployment }} -n {{ service }}-{{ deployment }}
+      when: with_fluentd_sidecar
+      changed_when: true
 
     - name: Check/import newer packit-service image into image stream
       ansible.builtin.command: oc import-image is/packit-service:{{ deployment }} -n {{ service }}-{{ deployment }}


### PR DESCRIPTION
When running `make import-images`, we were missing a fluentd sidecar image, so let's add it to the playbook :)

Signed-off-by: Matej Focko <mfocko@redhat.com>