### PR TITLE
Add resource requests & limits to fluentd sidecar

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -143,6 +143,9 @@ spec:
             - name: fluentd-config
               mountPath: /fluentd/etc
               readOnly: true
+          resources:
+            requests: {memory: "128Mi", cpu: "10m"}
+            limits: {memory: "128Mi", cpu: "100m"}
 {% endif %}
 ---
 kind: ImageStream


### PR DESCRIPTION
I initially didn't give (becf1012ae) the container any resource limits because with them it takes the container some time to start.

But we need them so that the pod is not in the `BestEffort` QoS class.

With requests set to 10m and limits to 100m we're in the `Burstable` class and `fluentd` starts a few seconds after the worker so it doesn't miss that much.