### PR TITLE
Yet another update of resource requests & limits

### DIFF
--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -32,13 +32,12 @@ spec:
             - name: DEPLOYMENT
               value: {{ deployment }}
           resources:
-            # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "128Mi"
               cpu: "20m"
             limits:
-              memory: "128Mi"
-              cpu: "20m"
+              memory: "256Mi"
+              cpu: "50m"
       volumes:
         - name: packit-secrets
           secret:

--- a/openshift/flower.yml
+++ b/openshift/flower.yml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: flower
-          image: mher/flower
+          image: docker.io/mher/flower
           env:
             - name: CELERY_BROKER_URL
               value: redis://redis:6379/0
@@ -28,10 +28,10 @@ spec:
           resources:
             requests:
               memory: "80Mi"
-              cpu: "20m"
+              cpu: "5m"
             limits:
-              memory: "80Mi"
-              cpu: "20m"
+              memory: "128Mi"
+              cpu: "50m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/nginx.yml.j2
+++ b/openshift/nginx.yml.j2
@@ -41,10 +41,9 @@ spec:
           mountPath: /etc/nginx/secrets
           readOnly: true
         resources:
-          # requests and limits have to be the same to have Guaranteed QoS
           requests:
-            memory: "32Mi"
-            cpu: "10m"
+            memory: "8Mi"
+            cpu: "1m"
           limits:
             memory: "32Mi"
             cpu: "10m"

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -64,13 +64,12 @@ spec:
           command:
             - "/usr/bin/run_worker.sh"
           resources:
-            # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "150Mi"
-              cpu: "10m"
+              memory: "160Mi"
+              cpu: "5m"
             limits:
-              memory: "150Mi"
-              cpu: "10m"
+              memory: "256Mi"
+              cpu: "50m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -39,13 +39,12 @@ spec:
             - name: packit-config
               mountPath: /home/packit/.config
           resources:
-            # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "80Mi"
-              cpu: "20m"
+              memory: "88Mi"
+              cpu: "5m"
             limits:
-              memory: "80Mi"
-              cpu: "20m"
+              memory: "128Mi"
+              cpu: "50m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -58,10 +58,10 @@ spec:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "{{ '1Gi' if project == 'packit-prod' else '128Mi' }}"
-              cpu: "{{ '300m' if project == 'packit-prod' else '100m' }}"
+              cpu: "{{ '100m' if project == 'packit-prod' else '50m' }}"
             limits:
               memory: "{{ '1Gi' if project == 'packit-prod' else '128Mi' }}"
-              cpu: "{{ '300m' if project == 'packit-prod' else '100m' }}"
+              cpu: "{{ '100m' if project == 'packit-prod' else '50m' }}"
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data

--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -24,10 +24,9 @@ spec:
           ports:
             - containerPort: 9091
           resources:
-            # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "32Mi"
-              cpu: "10m"
+              memory: "16Mi"
+              cpu: "1m"
             limits:
               memory: "32Mi"
               cpu: "10m"

--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -55,13 +55,12 @@ spec:
             - name: access-tokens
               mountPath: /access_tokens
           resources:
-            # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "80Mi"
-              cpu: "30m"
+              memory: "88Mi"
+              cpu: "5m"
             limits:
-              memory: "80Mi"
-              cpu: "30m"
+              memory: "128Mi"
+              cpu: "50m"
           ports:
             - containerPort: 8000
               protocol: "TCP"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -212,10 +212,10 @@
         worker_replicas: "{{ workers_short_running }}"
         # Short-running tasks are just interactions with different services.
         # They should not require a lot of memory/cpu.
-        worker_requests_memory: "320Mi"
-        worker_requests_cpu: "100m"
+        worker_requests_memory: "200Mi"
+        worker_requests_cpu: "50m"
         worker_limits_memory: "320Mi"
-        worker_limits_cpu: "100m"
+        worker_limits_cpu: "200m"
       ansible.builtin.include_tasks: tasks/k8s.yml
       loop:
         - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"


### PR DESCRIPTION
Use Burstable QoS for more/most pods, not just workers (d9278288).

Guaranteed QoS (when requests == limits) is the 'best' class, but you
have to carefully set the values (the same for requests and limits) so that
- it's enough for all use cases, but at the same time
- it's not too much because you'd waste the reserved (requested) resources.

And you actually don't need the generic workloads to be 'guaranteed'.
The Guaranteed QoS makes sense for the 'sensitive' workloads, like in
our case postgres and redis (maybe the service/api).

With the Burstable QoS (requests < limits) we can set
- requests to what the pod needs most of the time
- limits to some high value (more than what the pod needs in spikes)
  to have a safety net when a pod gets crazy
  - when it becomes a memory hog due to a memory leak
  - when it starts eating all cpu because of a bug