### PR TITLE
Set kerberos credentials/ticket cache location

### DIFF
--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -40,6 +40,8 @@ spec:
             - containerPort: 8443
               protocol: TCP
           env:
+            - name: PROJECT
+              value: {{ project }}
             - name: DEPLOYMENT
               value: {{ deployment }}
             - name: DISTGIT_URL
@@ -58,6 +60,9 @@ spec:
               valueFrom: {secretKeyRef: {name: postgres-secret, key: database-name}}
             - name: SENTRY_SECRET
               valueFrom: {secretKeyRef: {name: sentry, key: dsn}}
+            - name: SYSLOG_HOST
+              # localhost doesn't work
+              value: "127.0.0.1"
           volumeMounts:
             - name: packit-secrets
               mountPath: /secrets

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -98,6 +98,8 @@ spec:
             - name: SYSLOG_HOST
               # localhost doesn't work
               value: "127.0.0.1"
+            - name: KRB5CCNAME
+              value: "DIR:/home/packit/kerberos/"
           volumeMounts:
             - name: packit-ssh
               mountPath: /packit-ssh


### PR DESCRIPTION
 The `default_ccache_name = KEYRING:persistent:%{uid}` from `/etc/krb5.conf` didn't work for us after OpenShift 4.10->4.11 upgrade. We were getting `kinit: Function not implemented while getting default ccache`.

Kudos to @lachmanfrantisek 