### PR TITLE
Smaller repository_cache_storage

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -18,7 +18,7 @@
     with_beat: true
     with_pushgateway: true
     with_repository_cache: true
-    repository_cache_storage: 16Gi
+    repository_cache_storage: 4Gi
     with_sandbox: true
     push_dev_images: false
     with_fluentd_sidecar: false

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -43,7 +43,7 @@ with_flower: true
 # with_pushgateway: true
 
 # with_repository_cache: true
-repository_cache_storage: 10Gi
+# repository_cache_storage: 4Gi
 
 with_fluentd_sidecar: true
 

--- a/vars/packit/stg_template.yml
+++ b/vars/packit/stg_template.yml
@@ -38,7 +38,7 @@ with_flower: true
 # with_pushgateway: true
 
 # with_repository_cache: true
-# repository_cache_storage: 16Gi
+# repository_cache_storage: 4Gi
 
 with_fluentd_sidecar: true
 


### PR DESCRIPTION
4Gi for both prod and stg should be enough given that all worker pods say:
```
$ du -h /repository-cache/
20K     /repository-cache/
```

Until packit/packit-service#1840 is fixed.