### PR TITLE
Burstable QoS for postgres

### DIFF
--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -52,13 +52,12 @@ spec:
 #            successThreshold: 1
 #            timeoutSeconds: 1
           resources:
-            # requests and limits have to be the same to have Guaranteed QoS
             requests:
               memory: "{{ '1Gi' if project == 'packit-prod' else '128Mi' }}"
-              cpu: "{{ '100m' if project == 'packit-prod' else '50m' }}"
+              cpu: "30m"
             limits:
-              memory: "{{ '1Gi' if project == 'packit-prod' else '128Mi' }}"
-              cpu: "{{ '100m' if project == 'packit-prod' else '50m' }}"
+              memory: "{{ '2Gi' if project == 'packit-prod' else '256Mi' }}"
+              cpu: "300m"
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data


### PR DESCRIPTION
When I temporarily raised the mem limit to 2Gi on packit-prod a week ago the db became A LOT more responsive, (probably because the `shared_buffers` and `effective_cache_size` are set automatically based on the mem limit, see 2f07b23 commit message) while the total mem consumption stayed pretty much the same (maybe even a bit lower).

We can either play again (2f07b23) with setting the buffers & cache to higher values while keeping the pod in Guaranteed QoS (requests == limits). Or simply increase the limit permanently, which would change the QoS from Guaranteed to Burstable (limits > requests). I decided for the latter (see 3b0d20e for more info).