### PR TITLE
Import fedmsg image in fedora-source-git as well

### DIFF
--- a/cron-jobs/import-images/import-images.sh
+++ b/cron-jobs/import-images/import-images.sh
@@ -15,6 +15,9 @@ oc import-image is/fluentd:"${DEPLOYMENT}" -n "${NAMESPACE}"
 
 if [[ "${SERVICE}" == "packit" ]]; then
   oc import-image is/packit-dashboard:"${DEPLOYMENT}" -n "${NAMESPACE}"
-  oc import-image is/packit-service-fedmsg:"${DEPLOYMENT}" -n "${NAMESPACE}"
   oc import-image is/tokman:"${DEPLOYMENT}" -n "${NAMESPACE}"
+fi
+
+if [[ "${SERVICE}" != "stream" ]]; then
+  oc import-image is/packit-service-fedmsg:"${DEPLOYMENT}" -n "${NAMESPACE}"
 fi


### PR DESCRIPTION
I've just realized the fedora-source-git-prod was trying to pull old fedmsg image, because the cron-job hadn't import a newer one into the image stream.