### PR TITLE
Workers: add liveness probe

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -123,6 +123,16 @@ spec:
             limits:
               memory: {{ worker_limits_memory }}
               cpu: {{ worker_limits_cpu }}
+          livenessProbe:
+            exec:
+              command:
+                - bash
+                - '-c'
+                - 'celery -A $APP status | grep "$(uname -n): OK"'
+            # Start after 10m, every 5m with 1m timeout
+            initialDelaySeconds: 600
+            periodSeconds: 300
+            timeoutSeconds: 60
 {% if with_fluentd_sidecar %}
         # See ../docs/logs.md
         - name: fluentd-sidecar

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -203,10 +203,10 @@
         name: packit-worker
         queues: "short-running,long-running"
         worker_replicas: "{{ workers_all_tasks }}"
-        worker_requests_memory: "384Mi"
-        worker_requests_cpu: "20m"
-        worker_limits_memory: "384Mi"
-        worker_limits_cpu: "20m"
+        worker_requests_memory: "320Mi"
+        worker_requests_cpu: "10m"
+        worker_limits_memory: "640Mi"
+        worker_limits_cpu: "200m"
       ansible.builtin.include_tasks: tasks/k8s.yml
       loop:
         - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"
@@ -221,9 +221,9 @@
         worker_replicas: "{{ workers_short_running }}"
         # Short-running tasks are just interactions with different services.
         # They should not require a lot of memory/cpu.
-        worker_requests_memory: "200Mi"
+        worker_requests_memory: "320Mi"
         worker_requests_cpu: "50m"
-        worker_limits_memory: "320Mi"
+        worker_limits_memory: "640Mi"
         worker_limits_cpu: "200m"
       ansible.builtin.include_tasks: tasks/k8s.yml
       loop:


### PR DESCRIPTION
```
$ celery -A packit_service.worker.tasks status
->  celery@packit-worker-long-running-1: OK
->  celery@packit-worker-short-running-0: OK
2 nodes online.
```

The command usually takes about 7s to finish but can go up to 20-30s so the timeout is set to 1min to be on the safe side and not restart a worker needlessly.

There is no readiness probe because it IMHO makes no sense for pods with no inbound traffic.

We already had the probes a long time ago, but we removed them (94cee4a03) because they hadn't worked as expected.
Let's give it another try.

Related to packit/packit-service#1858