### PR TITLE
Revert unsetting OPENSSL_CONF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,7 @@ AP := ansible-playbook -vv -c local -i localhost, -e ansible_python_interpreter=
 TAGS ?= all
 
 download-secrets:
-	# Disable the system configuration for OpenSSL, so that older,
-	# deprecated algorithms can be used by Bitwarden CLI.
-	# TODO: Remove this, once the issue below is resolved.
-	# https://github.com/bitwarden/clients/issues/2726#issuecomment-1292153245
-	OPENSSL_CONF= ./scripts/download_secrets.sh
+	./scripts/download_secrets.sh
 
 # Mimic what we do during deployment when we render secret files
 # from their templates before we create k8s secrets from them.

--- a/scripts/download_secrets.sh
+++ b/scripts/download_secrets.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -eu
+
 # Script to
 # - login to Bitwarden and/or unlock the vault
 # - download all files attached to
@@ -16,7 +18,7 @@
 
 # If run via 'make deploy', you can use this (on your own risk) to
 # not download secrets again, if you just did it.
-[[ -n "${SKIP_SECRETS_SYNC}" || -n "${SSS}" ]] && { echo "Not downloading secrets"; exit 0; }
+[[ -n "${SKIP_SECRETS_SYNC:=}" || -n "${SSS:=}" ]] && { echo "Not downloading secrets"; exit 0; }
 
 # Set default values if not set already
 : "${SERVICE:=packit}"

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -13,14 +13,6 @@ use `make render-secrets-from-templates`.
 Use `scripts/update_bw_secret.sh` to update secrets, and don't have to click
 through the Bitwarden Web UI, deleting and uploading attachments.
 
-Due to an [issue with Bitwarden
-CLI](https://github.com/bitwarden/clients/issues/2726), set `OPENSSL_CONF` as
-an empty variable if using Fedora Linux, in order to allow older, deprecated
-cryptographic algorithms to be used. Without this
-`scripts/update_bw_secret.sh` will not work.
-
-    $ export OPENSSL_CONF=
-
 Here is the workflow how to do that:
 
 1. Make sure your local copy is up-to-date. For example:


### PR DESCRIPTION
The issues for which this was a workaround seems to be fixed in Bitwarden CLI v2023.1.0: https://github.com/bitwarden/clients/releases/tag/cli-v2023.1.0