### PR TITLE
Use fqcn for all modules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,17 +6,4 @@ skip_list:
 
 warn_list:
   - command-instead-of-module  # sometimes this is desired
-  - fqcn[action] # htpasswd -> community.general.web_infrastructure.htpasswd
-
-mock_modules:
-  # k8s module was moved to community.kubernetes collection in ansible 2.10
-  # and then later to kubernetes.core collection.
-  # Ansible 2.9.27 in F35 still contains the k8s module so we can ignore the error until F36,
-  # where we can switch to kubernetes.core.k8s as ansible-5.x in F36 contains it.
-  - k8s
-  # Ignore until F36, where these are in community.crypto collection (part of ansible-5.x rpm).
-  - openssh_keypair
-  - openssl_certificate
-  - openssl_csr
-  - openssl_privatekey
-  - htpasswd
+  - syntax-check[specific] # couldn't resolve module/action 'community.general.htpasswd'

--- a/cron-jobs/import-images/import-images.sh
+++ b/cron-jobs/import-images/import-images.sh
@@ -2,12 +2,10 @@
 
 oc login "${HOST}" --token="${TOKEN}" --insecure-skip-tls-verify
 
-set -x
+set -ux
 
-DEFAULT_SERVICE="packit"
-SERVICE="${SERVICE:-$DEFAULT_SERVICE}"
-DEFAULT_NAMESPACE="${SERVICE}-${DEPLOYMENT}"
-NAMESPACE="${NAMESPACE:-$DEFAULT_NAMESPACE}"
+: "${SERVICE:=packit}"
+: "${NAMESPACE:=${SERVICE}-${DEPLOYMENT}}"
 
 oc import-image is/packit-service:"${DEPLOYMENT}" -n "${NAMESPACE}"
 oc import-image is/packit-worker:"${DEPLOYMENT}" -n "${NAMESPACE}"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -187,7 +187,7 @@
     - name: Deploy repository cache PVCs for packit-workers that serves both queues
       vars:
         name: "packit-worker-{{ item }}"
-      k8s:
+      kubernetes.core.k8s:
         namespace: "{{ sandbox_namespace }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/sandcastle-volumes-for-cache.yml.j2') }}"
         host: "{{ host }}"
@@ -235,7 +235,7 @@
     - name: Deploy repository cache PVCs for packit-workers that serves long-running queue
       vars:
         name: "packit-worker-long-running-{{ item }}"
-      k8s:
+      kubernetes.core.k8s:
         namespace: "{{ sandbox_namespace }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/sandcastle-volumes-for-cache.yml.j2') }}"
         host: "{{ host }}"
@@ -281,7 +281,7 @@
         - dashboard
 
     - name: Create redis-commander secrets
-      k8s:
+      kubernetes.core.k8s:
         namespace: "{{ project }}"
         definition: "{{ lookup('template', '{{ project_dir }}/openshift/secret-redis-commander.yml.j2') }}"
         host: "{{ host }}"
@@ -322,7 +322,7 @@
       when: with_fedmsg
 
     - name: Deploy GitHub App Private Key
-      k8s:
+      kubernetes.core.k8s:
         namespace: "{{ project }}"
         resource_definition: "{{ lookup('template', '{{ project_dir }}/openshift/github-app-private-key.yml.j2') }}"
         host: "{{ host }}"
@@ -357,14 +357,14 @@
       when: with_flower
       block:
         - name: Create htpasswd file
-          htpasswd:
+          community.general.htpasswd:
             path: "{{ flower_htpasswd_path }}"
             name: "flower-boss"
             password: "{{ vault.flower.basic_auth | regex_replace('flower-boss:', '') }}"
             mode: 0640
         - name: Deploy flower-htpasswd secret
           # Don't use tasks/k8s.yml here because the loop item is always evaluated
-          k8s:
+          kubernetes.core.k8s:
             namespace: "{{ project }}"
             resource_definition: "{{ lookup('template', '{{ project_dir }}/openshift/secret-flower-htpasswd.yml.j2') }}"
             host: "{{ host }}"

--- a/playbooks/tasks/check-pod-running.yml
+++ b/playbooks/tasks/check-pod-running.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Getting pod for {{ item }}
-  k8s_info:
+  kubernetes.core.k8s_info:
     namespace: "{{ project }}"
     host: "{{ host }}"
     api_key: "{{ api_key }}"

--- a/playbooks/tasks/k8s.yml
+++ b/playbooks/tasks/k8s.yml
@@ -14,7 +14,7 @@
 #   https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#loops-and-conditionals
 - name: Create k8s object
   # https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_module.html
-  k8s:
+  kubernetes.core.k8s:
     namespace: "{{ project }}"
     resource_definition: "{{ item }}"
     host: "{{ host }}"

--- a/playbooks/tasks/wait_for_pod.yml
+++ b/playbooks/tasks/wait_for_pod.yml
@@ -3,7 +3,7 @@
 
 ---
 - name: Waiting for {{ pod_name }}
-  k8s:
+  kubernetes.core.k8s:
     namespace: "{{ project }}"
     host: "{{ host }}"
     api_key: "{{ api_key }}"

--- a/roles/generate-secrets/tasks/generate-cert.yml
+++ b/roles/generate-secrets/tasks/generate-cert.yml
@@ -9,7 +9,7 @@
   become: true
 
 - name: Generate OpenSSL private keys
-  openssl_privatekey:
+  community.crypto.openssl_privatekey:
     path: "{{ path_to_secrets }}/{{ item }}"
   loop:
     - private-key.pem
@@ -18,7 +18,7 @@
     - centos.cert
 
 - name: Generate OpenSSL CSR
-  openssl_csr:
+  community.crypto.openssl_csr:
     path: "{{ path_to_secrets }}/{{ item.csr }}"
     privatekey_path: "{{ path_to_secrets }}/{{ item.key }}"
     common_name: localhost
@@ -26,7 +26,7 @@
     - { key: privkey.pem, csr: fullchain.csr }
 
 - name: Generate Self Signed OpenSSL certificate
-  openssl_certificate:
+  community.crypto.x509_certificate:
     path: "{{ path_to_secrets }}/{{ item.cert }}"
     privatekey_path: "{{ path_to_secrets }}/{{ item.key }}"
     csr_path: "{{ path_to_secrets }}/{{ item.csr }}"

--- a/roles/generate-secrets/tasks/generate-ssh.yml
+++ b/roles/generate-secrets/tasks/generate-ssh.yml
@@ -3,5 +3,5 @@
 
 ---
 - name: Generate an OpenSSH keypair with the default values (4096 bits, rsa)
-  openssh_keypair:
+  community.crypto.openssh_keypair:
     path: "{{ path_to_secrets }}/id_rsa"


### PR DESCRIPTION
Previously this was not possible because the modules moved between Ansible 2.9 (previous Zuul) and 6 (Fedora).
[Zuul now runs Ansible 6](https://github.com/packit/packit-service-zuul/issues/73#issuecomment-1424353846) as well so let's go.