### PR TITLE
Double Postgresql memory requests & limits

### DIFF
--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -34,7 +34,7 @@ spec:
           resources:
             requests:
               memory: "128Mi"
-              cpu: "20m"
+              cpu: "1m"
             limits:
               memory: "256Mi"
               cpu: "50m"

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -66,7 +66,7 @@ spec:
           resources:
             requests:
               memory: "160Mi"
-              cpu: "5m"
+              cpu: "1m"
             limits:
               memory: "256Mi"
               cpu: "50m"

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -75,7 +75,7 @@ spec:
           resources:
             requests:
               memory: "320Mi"
-              cpu: "20m"
+              cpu: "10m"
             limits:
               # run_httpd.sh does 'alembic upgrade head' which might require more memory
               # If you see '/usr/bin/run_httpd.sh: line 16:   Killed     alembic upgrade head'

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -53,10 +53,10 @@ spec:
 #            timeoutSeconds: 1
           resources:
             requests:
-              memory: "{{ '1Gi' if project == 'packit-prod' else '128Mi' }}"
+              memory: "{{ '2Gi' if project == 'packit-prod' else '128Mi' }}"
               cpu: "30m"
             limits:
-              memory: "{{ '2Gi' if project == 'packit-prod' else '256Mi' }}"
+              memory: "{{ '4Gi' if project == 'packit-prod' else '256Mi' }}"
               cpu: "300m"
           volumeMounts:
             - name: postgres-data


### PR DESCRIPTION
it's been quite hungry since packit/packit-service#1787

and tune CPU requests of some workloads (they should still be enough in (almost) all cases)