### PR TITLE
Revert "Disable deployment-tests until we fix them"

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,7 +3,7 @@
     check:
       jobs:
         - pre-commit
-    #        - deployment-tests
+        - deployment-tests
     gate:
       jobs:
         - pre-commit

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -344,9 +344,12 @@
       when: with_tokman
 
     - name: Deploy tokman
-      ansible.builtin.include_tasks: tasks/k8s.yml
-      loop:
-        - "{{ lookup('template', '{{ project_dir }}/openshift/tokman.yml.j2') }}"
+      k8s:
+        namespace: "{{ project }}"
+        definition: "{{ lookup('template', '{{ project_dir }}/openshift/tokman.yml.j2') }}"
+        host: "{{ host }}"
+        api_key: "{{ api_key }}"
+        validate_certs: "{{ validate_certs }}"
       tags:
         - tokman
       register: tokman
@@ -383,9 +386,12 @@
             - Restart nginx deployment
 
     - name: Deploy nginx to reverse proxy the pushgateway and flower
-      ansible.builtin.include_tasks: tasks/k8s.yml
-      loop:
-        - "{{ lookup('template', '{{ project_dir }}/openshift/nginx.yml.j2') }}"
+      k8s:
+        namespace: "{{ project }}"
+        definition: "{{ lookup('template', '{{ project_dir }}/openshift/nginx.yml.j2') }}"
+        host: "{{ host }}"
+        api_key: "{{ api_key }}"
+        validate_certs: "{{ validate_certs }}"
       tags:
         - pushgateway
       register: nginx
@@ -420,18 +426,18 @@
   handlers:
     - name: Restart redis-commander deployment
       ansible.builtin.command: oc rollout restart deploy/redis-commander
-      # Run this rollout restart only if the Deployment above didn't change,
-      # and so it wasn't rolled out yet.
+      # Restart/rollout deployment as a reaction to config change
+      # when the deployment hasn't been changed itself.
       when: not redis_commander.changed
 
     - name: Restart tokman deployment
       ansible.builtin.command: oc rollout restart deploy/tokman
-      # Run this rollout restart only if the Deployment above didn't change,
-      # and so it wasn't rolled out yet.
+      # Restart/rollout deployment as a reaction to config change
+      # when the deployment hasn't been changed itself.
       when: not tokman.changed
 
     - name: Restart nginx deployment
       ansible.builtin.command: oc rollout restart deploy/nginx
-      # Run this rollout restart only if the Deployment above didn't change,
-      # and so it wasn't rolled out yet.
+      # Restart/rollout deployment as a reaction to config change
+      # when the deployment hasn't been changed itself.
       when: not nginx.changed

--- a/playbooks/zuul-deploy.yml
+++ b/playbooks/zuul-deploy.yml
@@ -11,7 +11,7 @@
           - ansible
           - python-openshift
           - python-pip
-          - python3-passlib # for using htpasswd ansible module
+          - python-passlib # for using htpasswd ansible module
           - make
       become: true
 


### PR DESCRIPTION
This reverts commit 71f67c0 done after the tests had mysteriously started to fail (on images being pulled to image streams)

So, I'm just checking (again :) ) whether it perhaps hasn't solved itself meanwhile :)
since we have a new major Zuul version deployed.