### PR TITLE
Configure the source-git services to override the package config path

### DIFF
--- a/secrets/fedora-source-git/prod/packit-service.yaml.j2
+++ b/secrets/fedora-source-git/prod/packit-service.yaml.j2
@@ -10,3 +10,5 @@ validate_webhooks: true
 
 server_name: prod.fedora-source-git.packit.dev
 # dashboard_url: https://dashboard.fedora-source-git.packit.dev
+
+package_config_path_override: .distro/source-git.yaml

--- a/secrets/fedora-source-git/stg/packit-service.yaml.j2
+++ b/secrets/fedora-source-git/stg/packit-service.yaml.j2
@@ -10,3 +10,5 @@ validate_webhooks: true
 
 server_name: stg.fedora-source-git.packit.dev
 # dashboard_url: https://dashboard.stg.fedora-source-git.packit.dev
+
+package_config_path_override: .distro/source-git.yaml

--- a/secrets/stream/prod/packit-service.yaml.j2
+++ b/secrets/stream/prod/packit-service.yaml.j2
@@ -16,3 +16,5 @@ enabled_private_namespaces:
 
 server_name: prod.stream.packit.dev
 dashboard_url: https://dashboard.stream.packit.dev
+
+package_config_path_override: .distro/source-git.yaml

--- a/secrets/stream/stg/packit-service.yaml.j2
+++ b/secrets/stream/stg/packit-service.yaml.j2
@@ -16,3 +16,5 @@ enabled_private_namespaces:
 
 server_name: stg.stream.packit.dev
 dashboard_url: https://dashboard.stg.stream.packit.dev
+
+package_config_path_override: .distro/source-git.yaml


### PR DESCRIPTION
This is going to be needed once packit/packit#1846 and packit/packit-service#1921 is merged.