### PR TITLE
Increase liveness probe values

### DIFF
--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -129,10 +129,11 @@ spec:
                 - bash
                 - '-c'
                 - 'celery -A $APP status | grep "$(uname -n): OK"'
-            # Start after 10m, every 5m with 1m timeout
+            # Start after 10m, every 10m with 5m timeout, 5 fails -> restart
+            failureThreshold: 5
             initialDelaySeconds: 600
-            periodSeconds: 300
-            timeoutSeconds: 60
+            periodSeconds: 600
+            timeoutSeconds: 300
 {% if with_fluentd_sidecar %}
         # See ../docs/logs.md
         - name: fluentd-sidecar


### PR DESCRIPTION
We need to be much less aggressive because the probe is still failing quite often.

The cause might be the [`solo` pool, which blocks the worker while it executes tasks](https://docs.celeryq.dev/en/latest/userguide/workers.html#remote-control).
For now, just try a longer timeout (5min should be enough for all tasks) and if that doesn't help, we can go back to `prefork` pool.