### PR TITLE
Tweak tokman resources and the number of workers

### DIFF
--- a/openshift/tokman.yml.j2
+++ b/openshift/tokman.yml.j2
@@ -38,7 +38,7 @@ spec:
             - name: LOG_LEVEL
               value: DEBUG
             - name: WORKERS
-              value: "1"
+              value: "{{ tokman.workers }}"
             - name: TOKMAN_CONFIG
               value: /etc/config/config.py
             - name: BIND_ADDR
@@ -54,22 +54,16 @@ spec:
               readOnly: true
             - name: access-tokens
               mountPath: /access_tokens
-          resources:
-            requests:
-              memory: "88Mi"
-              cpu: "5m"
-            limits:
-              memory: "128Mi"
-              cpu: "50m"
+          resources: {{ tokman.resources }}
           ports:
             - containerPort: 8000
               protocol: "TCP"
-          readinessProbe:
+          startupProbe:
             httpGet:
               path: /api/health
               port: 8000
             initialDelaySeconds: 15
-            timeoutSeconds: 2
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /api/health

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -52,6 +52,15 @@
     deployment_repo_url: https://github.com/packit/deployment.git
     # used by a few tasks below
     k8s_apply: false
+    tokman:
+      workers: 1
+      resources:
+        requests:
+          memory: "88Mi"
+          cpu: "5m"
+        limits:
+          memory: "128Mi"
+          cpu: "50m"
   tasks:
     - name: Include tasks/project-dir.yml
       ansible.builtin.include_tasks: tasks/project-dir.yml

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -82,3 +82,13 @@ workers_all_tasks: 0
 workers_short_running: 1
 workers_long_running: 2
 # pushgateway_address: http://pushgateway
+
+tokman:
+  workers: 2
+  resources:
+    requests:
+      memory: "160Mi"
+      cpu: "20m"
+    limits:
+      memory: "224Mi"
+      cpu: "50m"


### PR DESCRIPTION
Tokman had issues keeping up with the load on prod, which manifested in the liveness and readiness probes failing quite often, and occasionally ridiculous response times.

Using 2 gunicorn workers somewhat improves the situation, but that requires more resources. Update the playbook and the vars file for packit-prod accordingly.

Also change from using a readinessProbe to using a startupProbe. For tokman being ready and being live is the same: a response is received in a timely manner on /api/health. But we don't want to run the liveness probe before the startup has completed (the alembic migration completed and gunicorn started). Use the startup probe to check this. This will run only once, trying a few times, and stopping once successful. It might be that this was the intention with the readinessProbe in the first place :)