### PR TITLE
Get more resources for workers running both queues

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -212,10 +212,10 @@
         name: packit-worker
         queues: "short-running,long-running"
         worker_replicas: "{{ workers_all_tasks }}"
-        worker_requests_memory: "320Mi"
-        worker_requests_cpu: "10m"
-        worker_limits_memory: "640Mi"
-        worker_limits_cpu: "200m"
+        worker_requests_memory: "384Mi"
+        worker_requests_cpu: "100m"
+        worker_limits_memory: "1024Mi"
+        worker_limits_cpu: "400m"
       ansible.builtin.include_tasks: tasks/k8s.yml
       loop:
         - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"


### PR DESCRIPTION
Workers running both queues should get at least as much resources as workers handling only long running tasks.