### PR TITLE
tokman: reduce the number of workers and resources in packit prod

### DIFF
--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -84,11 +84,11 @@ workers_long_running: 2
 # pushgateway_address: http://pushgateway
 
 tokman:
-  workers: 2
+  workers: 1
   resources:
     requests:
-      memory: "160Mi"
+      memory: "100Mi"
       cpu: "20m"
     limits:
-      memory: "224Mi"
+      memory: "160Mi"
       cpu: "50m"


### PR DESCRIPTION
It turns out, that having 2 workers running in parallel will lead to a race condition, and there will be times when there are multiple tokens requested for the same repo. Avoid this, by dropping the number of workers to 1. Adjust resources accordingly.

Related to packit/tokman#53.