### PR TITLE
Add jontrossbach/xdp-tools to enabled_projects_for_internal_tf

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -17,6 +17,7 @@ enabled_projects_for_internal_tf:
   - github.com/r0x0d/leapp-packit-poc
   - github.com/teemtee/tmt
   - github.com/RedHat-SP-Security/keylime-tests
+  - github.com/jontrossbach/xdp-tools
 
 command_handler: sandcastle
 command_handler_work_dir: /tmp/sandcastle


### PR DESCRIPTION
See the chat

@jontrossbach is xdp-tools the only repo you need the internal Testing Farm enabled for?