### PR TITLE
Set SQLALCHEMY_WARN_20 to indicate legacy patterns

### DIFF
--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -66,6 +66,10 @@ spec:
             - name: SYSLOG_HOST
               # localhost doesn't work
               value: "127.0.0.1"
+{% if deployment != 'prod' %}
+            - name: SQLALCHEMY_WARN_20
+              value: "1"
+{% endif %}
           volumeMounts:
             - name: packit-secrets
               mountPath: /secrets

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -118,6 +118,10 @@ spec:
               value: "127.0.0.1"
             - name: KRB5CCNAME
               value: "DIR:/home/packit/kerberos/"
+{% if deployment != 'prod' %}
+            - name: SQLALCHEMY_WARN_20
+              value: "1"
+{% endif %}
           volumeMounts:
             - name: packit-ssh
               mountPath: /packit-ssh


### PR DESCRIPTION
[SQLAlchemy 2.0 was released](https://www.sqlalchemy.org/blog/2023/01/26/sqlalchemy-2.0.0-released/) in January 2023 and one of the steps in the [Migration Guide](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-two-turn-on-removedin20warnings) is to set `SQLALCHEMY_WARN_20=1` env. var. to see deprecation warnings.