### PR TITLE
Fix namespace for validation project in freedesktop

### DIFF
--- a/cron-jobs/packit-service-validation/packit-service-validation.py
+++ b/cron-jobs/packit-service-validation/packit-service-validation.py
@@ -721,7 +721,7 @@ if __name__ == "__main__":
         logging.info("Running validation for GitLab (gitlab.freedesktop.org instance).")
         GitlabTests(
             instance_url="https://gitlab.freedesktop.org/",
-            namespace="packit-validation",
+            namespace="packit-service",
             token_name="GITLAB_FREEDESKTOP_TOKEN",
         ).run()
     else:


### PR DESCRIPTION
In `gitlab.com` and `gitlab.freedesktop.org` we have a group as namespace -> `packit-service`
In `salsa.debian.org` and `gitlab.gnorme.org` we have the user namespace -> `packit-validation`