### PR TITLE
Fix cpu limit for postgres

### DIFF
--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -60,7 +60,7 @@ spec:
               cpu: "30m"
             limits:
               memory: "{{ '4Gi' if project == 'packit-prod' else '256Mi' }}"
-              cpu: "{{ '1Gi' if project == 'packit-prod' else '300m' }}"
+              cpu: "1"
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data


### PR DESCRIPTION
It's not `1Gi` (my mistake ace51c0) but `1` and it can be the same for prod and stg (since it's the limit, not the requests).