### PR TITLE
fix(c9s): enable postgresql module

### DIFF
--- a/containers/Containerfile.c9s
+++ b/containers/Containerfile.c9s
@@ -8,6 +8,7 @@ ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
 
 RUN dnf install -y epel-release 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
+    dnf module enable postgresql -y && \
     dnf update -y && \
     dnf install -y ansible python3-pip && \
     dnf clean all


### PR DESCRIPTION
With switch to MP+ we have also switched from PostgreSQL 13 to 15, this becomes an issue, since by default the C9S includes version 13 and regular backup is done from the worker.

Since we have multiple worker images, enable the ‹postgresql› module globally to reduce unnecessary copy-pasta into the playbooks for building workers.

Fixes #514