### PR TITLE
fix(mpp): add appcode and sandcastle's storage class

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -31,11 +31,16 @@ command_handler_pvc_volume_specs:
   - path: /repository-cache
     pvc_from_env: SANDCASTLE_REPOSITORY_CACHE_VOLUME
     read_only: true
+# [TODO]: Switch to ‹aws-ebs› during migration of prod to MP+
+command_handler_storage_class: gp2
 
 repository_cache: /repository-cache
 # The maintenance of the cache (adding, updating) is done externally,
 # not in the packit/packit-service code.
 add_repositories_to_repository_cache: false
+
+# [TODO]: Adjust, if needed, during migration of prod to MP+
+appcode: PCKT-002
 
 admins:  # GitHub usernames
   - jpopelka

--- a/secrets/packit/stg/packit-service.yaml.j2
+++ b/secrets/packit/stg/packit-service.yaml.j2
@@ -20,11 +20,14 @@ command_handler_pvc_volume_specs:
   - path: /repository-cache
     pvc_from_env: SANDCASTLE_REPOSITORY_CACHE_VOLUME
     read_only: true
+command_handler_storage_class: aws-ebs
 
 repository_cache: /repository-cache
 # The maintenance of the cache (adding, updating) is done externally,
 # not in the packit/packit-service code.
 add_repositories_to_repository_cache: false
+
+appcode: PCKT-002
 
 admins:  # GitHub usernames
   - jpopelka


### PR DESCRIPTION
Making ‹pass.redhat.com/appcode› and storage class for requested PVCs for sandcastle customizable.

Related to packit/sandcastle#190