### PR TITLE
fix: factor out deployment facts

### DIFF
--- a/playbooks/check.yml
+++ b/playbooks/check.yml
@@ -16,6 +16,9 @@
     - name: Include variables
       ansible.builtin.include_vars: "{{ project_dir }}/vars/{{ service }}/{{ deployment }}.yml"
 
+    - name: Include deployment facts
+      ansible.builtin.include_tasks: tasks/set-deployment-facts.yml
+
     - name: Include tasks/set-facts.yml
       ansible.builtin.include_tasks: tasks/set-facts.yml
 

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -79,6 +79,11 @@
       tags:
         - always
 
+    - name: Include deployment facts
+      ansible.builtin.include_tasks: tasks/set-deployment-facts.yml
+      tags:
+        - always
+
     - name: Include tasks/set-facts.yml
       ansible.builtin.include_tasks: tasks/set-facts.yml
       tags:

--- a/playbooks/render_secrets_from_templates.yml
+++ b/playbooks/render_secrets_from_templates.yml
@@ -6,7 +6,26 @@
 ---
 - name: Process templates with data from extra-vars.yml
   hosts: all
+  vars:
+    service: "{{ lookup('env', 'SERVICE') | default('packit', True) }}"
+    deployment: "{{ lookup('env', 'DEPLOYMENT') }}"
+    tenant: packit # MP+ tenant
   tasks:
+    - name: Include tasks/project-dir.yml
+      ansible.builtin.include_tasks: tasks/project-dir.yml
+      tags:
+        - always
+
+    - name: Include variables
+      ansible.builtin.include_vars: "{{ project_dir }}/vars/{{ service }}/{{ deployment }}.yml"
+      tags:
+        - always
+
+    - name: Include tasks/set-facts.yml
+      ansible.builtin.include_tasks: tasks/set-facts.yml
+      tags:
+        - rendering-templates
+
     - name: Include extra secret vars
       ansible.builtin.include_vars:
         file: "{{ path_to_secrets }}/extra-vars.yml"

--- a/playbooks/tasks/set-deployment-facts.yml
+++ b/playbooks/tasks/set-deployment-facts.yml
@@ -1,0 +1,38 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+# We call the facts deploymentconfigs even they are not DeploymentConfigs but Deployments
+# because we already use the term 'deployment' for something else (prod/stg).
+
+---
+- name: Set mandatory_deploymentconfigs fact
+  ansible.builtin.set_fact:
+    mandatory_deploymentconfigs:
+      - postgres-{{ postgres_version }}
+      - redis
+      - packit-service
+  tags:
+    - always
+- name: Set optional_deploymentconfigs fact
+  ansible.builtin.set_fact:
+    optional_deploymentconfigs:
+      tokman: "{{ with_tokman }}"
+      packit-service-fedmsg: "{{ with_fedmsg }}"
+      packit-service-beat: "{{ with_beat }}"
+      packit-dashboard: "{{ with_dashboard }}"
+      pushgateway: "{{ with_pushgateway }}"
+      nginx: "{{ with_pushgateway }}"
+  tags:
+    - always
+- name: Set deploymentconfigs fact
+  ansible.builtin.set_fact:
+    # To know what DCs rollouts to wait for and also to check in tests
+    deploymentconfigs: '{{ mandatory_deploymentconfigs + optional_deploymentconfigs | dict2items | selectattr("value", "equalto", true) | list | map(attribute="key") | flatten }}'
+  tags:
+    - always
+
+- name: Set flower_htpasswd_path
+  ansible.builtin.set_fact:
+    flower_htpasswd_path: "{{ path_to_secrets }}/flower-htpasswd"
+  tags:
+    - flower

--- a/playbooks/tasks/set-facts.yml
+++ b/playbooks/tasks/set-facts.yml
@@ -1,42 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-# We call the facts deploymentconfigs even they are not DeploymentConfigs but Deployments
-# because we already use the term 'deployment' for something else (prod/stg).
-
 ---
-- name: Set mandatory_deploymentconfigs fact
-  ansible.builtin.set_fact:
-    mandatory_deploymentconfigs:
-      - postgres-{{ postgres_version }}
-      - redis
-      - packit-service
-  tags:
-    - always
-- name: Set optional_deploymentconfigs fact
-  ansible.builtin.set_fact:
-    optional_deploymentconfigs:
-      tokman: "{{ with_tokman }}"
-      packit-service-fedmsg: "{{ with_fedmsg }}"
-      packit-service-beat: "{{ with_beat }}"
-      packit-dashboard: "{{ with_dashboard }}"
-      pushgateway: "{{ with_pushgateway }}"
-      nginx: "{{ with_pushgateway }}"
-  tags:
-    - always
-- name: Set deploymentconfigs fact
-  ansible.builtin.set_fact:
-    # To know what DCs rollouts to wait for and also to check in tests
-    deploymentconfigs: '{{ mandatory_deploymentconfigs + optional_deploymentconfigs | dict2items | selectattr("value", "equalto", true) | list | map(attribute="key") | flatten }}'
-  tags:
-    - always
-
-- name: Set flower_htpasswd_path
-  ansible.builtin.set_fact:
-    flower_htpasswd_path: "{{ path_to_secrets }}/flower-htpasswd"
-  tags:
-    - flower
-
 - name: Set managed_platform
   ansible.builtin.set_fact:
     managed_platform: "{{ 'api.mpp' in host }}"
@@ -48,6 +13,7 @@
     with_sandbox: "{{ service == 'packit' }}"
   tags:
     - always
+
 - name: Set sandbox_namespace
   when: with_sandbox
   tags:


### PR DESCRIPTION
To enable including them only in deployment, and therefore allow rendering of templates where we don't need to have all of the ansible facts related to deployment.