### PR TITLE
fix(move-stable): pull the monorepo changes first

### DIFF
--- a/scripts/move_stable.py
+++ b/scripts/move_stable.py
@@ -477,6 +477,12 @@ def update_monorepo(
     if repository:
         update_command.append(repository)
 
+    # pull changes done by others
+    subprocess.run(
+        ["git", "pull"],
+        cwd=path_to_monorepo,
+    )
+
     # update the references
     subprocess.run(
         update_command,


### PR DESCRIPTION
When updating the references to the ‹stable›, we need to pull the changes done by the others first.