### PR TITLE
feat: use staging TF API on stage

### DIFF
--- a/secrets/packit/stg/packit-service.yaml.j2
+++ b/secrets/packit/stg/packit-service.yaml.j2
@@ -8,7 +8,7 @@ validate_webhooks: true
 
 {{ vault.packit_service | to_nice_yaml }}
 
-testing_farm_api_url: https://api.dev.testing-farm.io/v0.1/
+testing_farm_api_url: https://api.staging.testing-farm.io/v0.1/
 enabled_projects_for_internal_tf:
   - github.com/packit/hello-world
   - github.com/oamg/convert2rhel


### PR DESCRIPTION
As it was suggested by @thrix (@mvadkert), we should use staging API of Testing Farm on our staging instance to test and validate their changes.

Given the fact there are not many users of Packit staging instance apart from Packit Team and Packit Validation, we should be able to verify the TF changes before they land on **both** TF and Packit production, which should in turn increase overall stability of Testing Farm experience while using Packit.