### PR TITLE
fix: switch TF API URL to the production API endpoint

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -7,7 +7,7 @@ validate_webhooks: true
 
 {{ vault.packit_service | to_nice_yaml }}
 
-testing_farm_api_url: https://api.dev.testing-farm.io/v0.1/
+testing_farm_api_url: https://api.testing-farm.io/v0.1/
 enabled_projects_for_internal_tf:
   - github.com/packit/hello-world
   - github.com/oamg/convert2rhel


### PR DESCRIPTION
Fixes #546