### PR TITLE
fix: raise the memory for ‹redis›

### DIFF
--- a/openshift/redis.yml.j2
+++ b/openshift/redis.yml.j2
@@ -29,10 +29,10 @@ spec:
           resources:
             # requests and limits have to be the same to have Guaranteed QoS
             requests:
-              memory: "32Mi"
+              memory: "64Mi"
               cpu: "10m"
             limits:
-              memory: "32Mi"
+              memory: "64Mi"
               cpu: "10m"
       volumes:
         - name: redis-pv


### PR DESCRIPTION
Raise the memory requirement of redis, since between

    quay.io/sclorg/redis-6-c9s@sha256:953accd44700b26f8de13d6768124e326e6e15f9854825cc99890d502bdb3fbe

and

    quay.io/sclorg/redis-6-c9s@sha256:b1a6ab6752e328f8759aebaab614043b2152e21b3fca3a310a52c630ec939a7c

the memory consumption increased by 2 times… This issue has been detected on stage.