### PR TITLE
chore: bump redis from 6 to 7

### DIFF
--- a/openshift/redis.yml.j2
+++ b/openshift/redis.yml.j2
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: quay.io/sclorg/redis-6-c9s
+          image: quay.io/sclorg/redis-7-c9s
           ports:
             - containerPort: 6379
           volumeMounts:


### PR DESCRIPTION
As suggested by @jpopelka in #555, there's also a new redis image of version 7 being present.

Scaled down workers before bumping the image, looks like it went without any hiccups