### PR TITLE
fix: bump postgres in the base image

### DIFF
--- a/containers/Containerfile.c9s
+++ b/containers/Containerfile.c9s
@@ -8,7 +8,7 @@ ENV ANSIBLE_PYTHON_INTERPRETER=/usr/bin/python3 \
 
 RUN dnf -y install epel-release && \
     crb enable && \
-    dnf -y module enable postgresql:15 && \
+    dnf -y module enable postgresql:16 && \  # TODO: revert this change after psql:15 works fine
     dnf -y upgrade && \
     dnf -y install ansible python3-pip && \
     dnf clean all


### PR DESCRIPTION
As the cache of the postgresql:15 builds expired, we ran into some issues with regards to the service builds that depend on postgresql for the ‹pg_dump›. Since 16 is not affected by this issue, bump the module for now and revert later once psql:15 is available again.
