### PR TITLE
fix: fix typos in the exceptions for limits

### DIFF
--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -84,7 +84,7 @@ spec:
               # If you see '/usr/bin/run_httpd.sh: line 16:   Killed     alembic upgrade head'
               # you have to temporarily increase (in webUI/console) the limit
               # and once the alembic upgrade passes, revert.
-              memory: "{{ '4Gi' if project == 'packit-prod' else '512Mi' }}"
+              memory: "{{ '4Gi' if project == 'packit--prod' else '512Mi' }}"
               cpu: "200m"
           # In TLS world, hostname needs to match whatever is set in the cert
           # in our cause, k8s is doing here something like curl https://172.15.2.4:8443/api/healthz/

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -53,12 +53,12 @@ spec:
 #                - /usr/libexec/check-container
           resources:
             requests:
-              memory: "{{ '2Gi' if project == 'packit-prod' else '128Mi' }}"
+              memory: "{{ '2Gi' if project == 'packit--prod' else '128Mi' }}"
               cpu: "30m"
             limits:
 # The shared_buffers & effective_cache_size values are set by the container
 # based on this limit, so keep the limit reasonably high.
-              memory: "{{ '4Gi' if project == 'packit-prod' else '256Mi' }}"
+              memory: "{{ '4Gi' if project == 'packit--prod' else '256Mi' }}"
 # Not utilized most of the time, but useful during migrations and for some queries
               cpu: "1"
           volumeMounts:

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -6,7 +6,9 @@
 # -------------------------------------------------------------------
 
 # Openshift project/namespace name
-project: packit-prod
+# [WARNING] Be careful when changing this value as it is explicitly checked in
+# the Packit Service (API) and postgresql deployments
+project: packit--prod
 
 # Openshift cluster url
 # For the URL of the MP+ API endpoint, see Bitwarden Secure note


### PR DESCRIPTION
After switching our deployment to MP+ we (read as “me”) missed some occurences of hardcoded project/namespace for Packit Service deployment.

* Fix those typos.
* Add warning to the template.