### PR TITLE
fix(imagestream): use quay.io images for nginx

### DIFF
--- a/openshift/nginx.yml.j2
+++ b/openshift/nginx.yml.j2
@@ -149,7 +149,7 @@ spec:
     - name: {{ deployment }}
       from:
         kind: DockerImage
-        name: ghcr.io/nginxinc/nginx-unprivileged
+        name: quay.io/nginx/nginx-unprivileged:latest
       importPolicy:
         # Periodically query registry to synchronize tag and image metadata.
         scheduled: {{ auto_import_images }}


### PR DESCRIPTION
Use nginx image from quay.io instead of ghcr.io, since it doesn't get “rate-limited”.