### PR TITLE
Customize shm size in postgres pod

### DIFF
--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -84,7 +84,7 @@ spec:
               # If you see '/usr/bin/run_httpd.sh: line 16:   Killed     alembic upgrade head'
               # you have to temporarily increase (in webUI/console) the limit
               # and once the alembic upgrade passes, revert.
-              memory: "{{ '4Gi' if project == 'packit--prod' else '512Mi' }}"
+              memory: "{{ '1Gi' if project == 'packit--prod' else '512Mi' }}"
               cpu: "200m"
           # In TLS world, hostname needs to match whatever is set in the cert
           # in our cause, k8s is doing here something like curl https://172.15.2.4:8443/api/healthz/

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -58,12 +58,12 @@ spec:
 #                - /usr/libexec/check-container
           resources:
             requests:
-              memory: "{{ '2Gi' if project == 'packit--prod' else '256Mi' }}"
+              memory: "{{ '1Gi' if project == 'packit--prod' else '256Mi' }}"
               cpu: "30m"
             limits:
 # The shared_buffers & effective_cache_size values are set by the container
 # based on this limit, so keep the limit reasonably high.
-              memory: "{{ '4Gi' if project == 'packit--prod' else '512Mi' }}"
+              memory: "{{ '1536Mi' if project == 'packit--prod' else '512Mi' }}"
 # Not utilized most of the time, but useful during migrations and for some queries
               cpu: "1"
           volumeMounts:

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -35,6 +35,11 @@ spec:
           ports:
             - containerPort: 5432
               protocol: TCP
+          # increase shm size, default is 64M
+          # dashboard usage page requires around 100MB
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: cache-volume
           livenessProbe:
             exec:
               command:
@@ -53,12 +58,12 @@ spec:
 #                - /usr/libexec/check-container
           resources:
             requests:
-              memory: "{{ '2Gi' if project == 'packit--prod' else '128Mi' }}"
+              memory: "{{ '2Gi' if project == 'packit--prod' else '256Mi' }}"
               cpu: "30m"
             limits:
 # The shared_buffers & effective_cache_size values are set by the container
 # based on this limit, so keep the limit reasonably high.
-              memory: "{{ '4Gi' if project == 'packit--prod' else '256Mi' }}"
+              memory: "{{ '4Gi' if project == 'packit--prod' else '512Mi' }}"
 # Not utilized most of the time, but useful during migrations and for some queries
               cpu: "1"
           volumeMounts:
@@ -75,6 +80,11 @@ spec:
         - name: postgres-config
           configMap:
             name: postgres-config
+        - name: cache-volume
+          emptyDir:
+            medium: Memory
+            sizeLimit: 128Mi
+
   replicas: 1
   strategy:
     type: Recreate


### PR DESCRIPTION
By default shm size is 64MB, *dashboard usage* page uses around 100MB.

I can reproduce the error described in packit/packit-service#2385 locally using podman compose and I can fix it by setting `shm_size: 128Mi` in `docker-compose.yml`.

I tried deploying these openshift changes on my local openshift cluster but even though the new volume is created and mapped the size didn't change.

`df -h /dev/shm` is always 64MB

I would like to test this on stg, to be sure the problem is not related with my local openshift cluster.

But, as far as I can understand it, does exist a `SizeMemoryBackedVolumes` k8s *feature gate*, which is not enabled in the cluster by default (probably because this is a  dangerous feature https://github.com/kubernetes/kubernetes/issues/119611).
If this is not enabled in the cluster, resizing can not occur.

If this PR will not work on stg I think we have 2 solutions:
- ask to the cluster's maintainers if they have a way to increase shared memory for our pod
- redesign db queries in usage page