### PR TITLE
fix(scripts): warn about the vars dependency

### DIFF
--- a/scripts/render_secrets_from_templates.sh
+++ b/scripts/render_secrets_from_templates.sh
@@ -17,3 +17,5 @@ ansible-playbook -v -c local -i localhost, \
                  -e path_to_secrets="$(realpath "${PATH_TO_SECRETS}")" \
                  -e service="${SERVICE}" \
                  playbooks/render_secrets_from_templates.yml
+
+echo "[WARNING] Please make sure your ‹vars/› are up-to-date, since the rendered secrets may depend on it."


### PR DESCRIPTION
When rendering the secrets, e.g., config template, via script, we run some parts of the playbooks that may depend on the variables for a deployment (like MP+ vs Automotive, and such). Warn about this fact to make sure there are no discrepancies introduced by outdated “secrets”.