### PR TITLE
feat(centpkg-sig): override the default config

### DIFF
--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -39,6 +39,9 @@ spec:
         - name: gh-secrets
           secret:
             secretName: github-app-private-key
+        - name: centpkg-sig
+          secret:
+            secretName: centpkg-sig
       containers:
         - name: packit-service
           image: packit-service:{{ deployment }}
@@ -79,6 +82,9 @@ spec:
             - name: gh-secrets
               mountPath: /gh-secrets
               readOnly: true
+            - name: centpkg-sig
+              mountPath: /etc/rpkg/centpkg-sig.conf
+              subPath: centpkg-sig.conf
           command:
             - /usr/bin/run_httpd.sh
           resources:

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -76,6 +76,9 @@ spec:
         - name: gh-secrets
           secret:
             secretName: github-app-private-key
+        - name: centpkg-sig
+          secret:
+            secretName: centpkg-sig
       containers:
         - name: packit-worker
           image: packit-worker:{{ deployment }}
@@ -146,6 +149,9 @@ spec:
             - name: gh-secrets
               mountPath: /gh-secrets
               readOnly: true
+            - name: centpkg-sig
+              mountPath: /etc/rpkg/centpkg-sig.conf
+              subPath: centpkg-sig.conf
           command:
             - "/usr/bin/run_worker.sh"
           resources:

--- a/openshift/secret-centpkg-sig.yml.j2
+++ b/openshift/secret-centpkg-sig.yml.j2
@@ -1,0 +1,11 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: centpkg-sig
+type: Opaque
+data:
+  centpkg-sig.conf: "{{ lookup('template', '{{ path_to_secrets }}/centpkg-sig.conf.j2', rstrip=False) | b64encode }}"

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -155,6 +155,7 @@
         - "{{ lookup('template', '{{ project_dir }}/openshift/secret-postgres.yml.j2') }}"
         - "{{ lookup('template', '{{ project_dir }}/openshift/secret-aws.yml.j2') }}"
         - "{{ lookup('template', '{{ project_dir }}/openshift/secret-splunk.yml.j2') }}"
+        - "{{ lookup('template', '{{ project_dir }}/openshift/secret-centpkg-sig.yml.j2') }}"
       tags:
         - secrets
 

--- a/playbooks/render_secrets_from_templates.yml
+++ b/playbooks/render_secrets_from_templates.yml
@@ -43,3 +43,10 @@
         dest: "{{ path_to_secrets }}/fedora.toml"
         mode: "0644"
       when: service != 'stream'
+
+    - name: Process centpkg-sig.conf.j2 template
+      ansible.builtin.template:
+        src: "{{ path_to_secrets }}/centpkg-sig.conf.j2"
+        dest: "{{ path_to_secrets }}/centpkg-sig.conf"
+        mode: "0644"
+      when: service != 'stream'

--- a/secrets/packit/prod/centpkg-sig.conf.j2
+++ b/secrets/packit/prod/centpkg-sig.conf.j2
@@ -1,0 +1,32 @@
+[centpkg-sig]
+lookaside = https://git.centos.org/sources
+lookasidehash = sha512
+lookaside_cgi = https://git.centos.org/sources/upload_sig.cgi
+# lookaside_cgi = https://git.centos.org/sources/upload.cgi
+distgit_namespaced = True
+distgit_namespaces = rpms
+gitbaseurl = git+ssh://git@gitlab.com/CentOS/%(repo)s.git
+anongiturl = https://gitlab.com/CentOS/%(repo)s.git
+branchre = c\d+s?-sig-.+|master$
+kojiprofile = cbs
+build_client = cbs
+lookaside_namespaced = True
+git_excludes =
+  i386/
+  i686/
+  x86_64/
+  ppc/
+  ppc64/
+  ia64/
+  mips/
+  arm/
+  noarch/
+  /*.src.rpm
+  /build*.log
+  /.build-*.log
+  results_*/
+  clog
+
+[centpkg-sig.distgit]
+apibaseurl = https://gitlab.com
+token = {{ vault.packit_service.authentication['gitlab.com'].token }}

--- a/secrets/packit/stg/centpkg-sig.conf.j2
+++ b/secrets/packit/stg/centpkg-sig.conf.j2
@@ -1,0 +1,32 @@
+[centpkg-sig]
+lookaside = https://git.centos.org/sources
+lookasidehash = sha512
+lookaside_cgi = https://git.centos.org/sources/upload_sig.cgi
+# lookaside_cgi = https://git.centos.org/sources/upload.cgi
+distgit_namespaced = True
+distgit_namespaces = rpms
+gitbaseurl = git+ssh://git@gitlab.com/CentOS/%(repo)s.git
+anongiturl = https://gitlab.com/CentOS/%(repo)s.git
+branchre = c\d+s?-sig-.+|master$
+kojiprofile = cbs
+build_client = cbs
+lookaside_namespaced = True
+git_excludes =
+  i386/
+  i686/
+  x86_64/
+  ppc/
+  ppc64/
+  ia64/
+  mips/
+  arm/
+  noarch/
+  /*.src.rpm
+  /build*.log
+  /.build-*.log
+  results_*/
+  clog
+
+[centpkg-sig.distgit]
+apibaseurl = https://gitlab.com
+token = {{ vault.packit_service.authentication['gitlab.com'].token }}


### PR DESCRIPTION
Override the default config, since we are going to require the usage of GitLab.com for more streamlined experience across both CentOS Stream and CentOS SIGs.

Fixes packit/packit#2305
