### PR TITLE
fix(move-stable): remove archived repos

### DIFF
--- a/scripts/move_stable.py
+++ b/scripts/move_stable.py
@@ -25,9 +25,7 @@ REPOSITORIES: List[str] = [
     "packit-service-fedmsg",
     "sandcastle",
     "dashboard",
-    "tokman",
     "packit-service",
-    "hardly",
 ]
 REPOS_FOR_BLOG: List[str] = [
     "packit",


### PR DESCRIPTION
1. Remove tokman as it is no longer deployed.
2. Remove hardly as it is no longer deployed either.
