### PR TITLE
chore: use k8s_apply=true by default

### DIFF
--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -54,7 +54,7 @@
     check_vars_template_diff: true
     deployment_repo_url: https://github.com/packit/deployment.git
     # used by a few tasks below
-    k8s_apply: false
+    k8s_apply: true
     tokman:
       workers: 1
       resources:
@@ -184,8 +184,6 @@
         - postgres
 
     - name: Deploy redis
-      vars:
-        k8s_apply: true
       ansible.builtin.include_tasks: tasks/k8s.yml
       loop:
         - "{{ lookup('template', '{{ project_dir }}/openshift/redis.yml.j2') }}"
@@ -194,8 +192,6 @@
         - redis
 
     - name: Deploy redict
-      vars:
-        k8s_apply: true
       ansible.builtin.include_tasks: tasks/k8s.yml
       loop:
         - "{{ lookup('template', '{{ project_dir }}/openshift/redict.yml.j2') }}"

--- a/playbooks/roles/deploy/defaults/main.yml
+++ b/playbooks/roles/deploy/defaults/main.yml
@@ -47,7 +47,7 @@ check_up_to_date: true # noqa: var-naming[no-role-prefix]
 check_vars_template_diff: true # noqa: var-naming[no-role-prefix]
 deployment_repo_url: https://github.com/packit/deployment.git # noqa: var-naming[no-role-prefix]
 # used by a few tasks below
-k8s_apply: false # noqa: var-naming[no-role-prefix]
+k8s_apply: true # noqa: var-naming[no-role-prefix]
 tokman: # noqa: var-naming[no-role-prefix]
   workers: 1
   resources:

--- a/playbooks/roles/deploy/tasks/main.yml
+++ b/playbooks/roles/deploy/tasks/main.yml
@@ -142,8 +142,6 @@
     - postgres
 
 - name: Deploy redis
-  vars:
-    k8s_apply: true
   ansible.builtin.include_tasks: tasks/k8s.yml
   loop:
     - "{{ lookup('template', '{{ project_dir }}/openshift/redis.yml.j2') }}"
@@ -152,8 +150,6 @@
     - redis
 
 - name: Deploy redict
-  vars:
-    k8s_apply: true
   ansible.builtin.include_tasks: tasks/k8s.yml
   loop:
     - "{{ lookup('template', '{{ project_dir }}/openshift/redict.yml.j2') }}"


### PR DESCRIPTION
• Summary

Initially I wanted to do ‹k8s_apply=false› for postgres, and key-value
databases (such as Redis, Redict, or Valkey), because deploying on prod
with ‹k8s_apply=true› caused redeployment of the postgres which caused
a small outage (~5 minutes).

Right now when I tried to redeploy stage multiple times in a row, none of
the deployed services got redeployed, hence I come to the conclusion that
there were some changes on the production deployment that were applied
back then.

• Context from https://github.com/packit/deployment/issues/360

  · What it actually does?

    In the simple terms, it makes sure that the definition that is to be
    deployed matches the one that is already deployed. The difference has
    already manifested few times, e.g., when @majamassarini was adjusting
    the `/dev/shm` for the postgres deployment (https://github.com/mfocko/deployment/commit/bedef2026c84ea00bb329799cc9bef81687fe88d), the change did
    not get deployed.

  · Why some tasks already use it (e.g., Redis/Redict, Flower secret) and
    others not?

    not sure

  · Would it make sense to default to ‹apply=true›?

    Yes, but at the same time, applying meaningless changes to critical
    services, e.g., postgres or Redis/Redict/Valkey, can cause smaller
    outages.

Fixes https://github.com/packit/deployment/issues/360