### PR TITLE
chore(postgres): enlarge the postgres volume

### DIFF
--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -137,7 +137,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: "{{ '4Gi' if deployment == 'prod' else '1Gi' }}"
+      storage: "{{ '8Gi' if deployment == 'prod' else '2Gi' }}"
 {% if managed_platform %}
   storageClassName: aws-ebs
 {% endif %}


### PR DESCRIPTION
Also resized the stage for the testing purposes, it ain't much(, but it's an honest work), if we reserve a lot of resources on preprod, we can relax it (we're using barely 300MB on stage).

Turns out that you, indeed, can resize the PVC with the pod running and then just rescale the deployment (postgres).

Fixes #604