### PR TITLE
Allow github.com/rhel-lightspeed/command-line-assistant to use internal TF

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -41,6 +41,7 @@ enabled_projects_for_internal_tf:
   - github.com/rear/rear
   - github.com/RedHatInsights/rhc-worker-playbook
   - github.com/RedHat-SP-Security/clevis-tests
+  - github.com/rhel-lightspeed/command-line-assistant
 
 command_handler: sandcastle
 command_handler_work_dir: /tmp/sandcastle

--- a/secrets/packit/stg/packit-service.yaml.j2
+++ b/secrets/packit/stg/packit-service.yaml.j2
@@ -44,6 +44,7 @@ enabled_projects_for_internal_tf:
   - github.com/rear/rear
   - github.com/RedHatInsights/rhc-worker-playbook
   - github.com/RedHat-SP-Security/clevis-tests
+  - github.com/rhel-lightspeed/command-line-assistant
 
 
 command_handler: sandcastle


### PR DESCRIPTION
We need to run internal TF jobs on the https://github.com/rhel-lightspeed/command-line-assistant project.