### PR TITLE
fix(valkey): pin to major release (8)

### DIFF
--- a/openshift/valkey.yml.j2
+++ b/openshift/valkey.yml.j2
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: valkey
-          image: valkey/valkey:8.0.0
+          image: valkey/valkey:8
           args:
             - "/etc/redislike/redis.conf"
           ports:


### PR DESCRIPTION
After a discussion with @lbarcziova and revisiting the reappearing MP+ vulnerability reports, I've noticed I pinned the Valkey to use 8.0.0.

We do not strictly require the 8.0.0 and one patch release has already happened, so I'm relaxing this requirement to require only major release 8.