### PR TITLE
Fix base image build

### DIFF
--- a/.github/workflows/base-image-rebuild.yml
+++ b/.github/workflows/base-image-rebuild.yml
@@ -18,18 +18,10 @@ jobs:
     name: Build and push image
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         include:
           - containerfile: containers/Containerfile
             tags: "fedora latest"
-            archs: "amd64"
-          - containerfile: containers/Containerfile
-            tags: "fedora latest"
-            archs: "arm64"
-          - containerfile: containers/Containerfile
-            tags: "fedora latest"
-            archs: "ppc64le"
 
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +38,9 @@ jobs:
           containerfiles: ${{ matrix.containerfile }}
           image: base
           tags: ${{ matrix.tags }}
-          archs: ${{ matrix.archs }}
+          # for some reason building ppc64le image fails on F41 OpenSSL
+          # not being able to verify certificates, keep it disabled for now
+          archs: amd64, arm64
           # Uncomment once we stop using oc cluster up for tests
           #           oci: true
 


### PR DESCRIPTION
I don't know what's wrong, it looks like OpenSSL on Fedora 41 ppc64le doesn't support SHA384 (but I'm not able to reproduce it outside of Github Actions environment):

```bash
$ openssl s_client -servername mirrors.fedoraproject.org -connect mirrors.fedoraproject.org:443 < /dev/null
Connecting to 140.211.169.196
depth=2 C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G3
verify return:1
depth=1 C=US, O=DigiCert Inc, CN=DigiCert Global G3 TLS ECC SHA384 2020 CA1
verify error:num=7:certificate signature failure
verify return:1
depth=1 C=US, O=DigiCert Inc, CN=DigiCert Global G3 TLS ECC SHA384 2020 CA1
verify return:1
depth=0 C=US, ST=North Carolina, L=Raleigh, O=Red Hat, Inc., CN=*.fedoraproject.org
verify error:num=7:certificate signature failure
verify return:1
depth=0 C=US, ST=North Carolina, L=Raleigh, O=Red Hat, Inc., CN=*.fedoraproject.org
verify return:1
```

Disabling certificate verification is an ugly workaround, but it makes it work:
https://github.com/packit/deployment/actions/runs/12256772166