### PR TITLE
Increase cpu limit to handle spikes better

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -206,7 +206,7 @@
     worker_requests_memory: "320Mi"
     worker_requests_cpu: "80m"
     worker_limits_memory: "640Mi"
-    worker_limits_cpu: "700m"
+    worker_limits_cpu: "4"
   ansible.builtin.include_tasks: k8s.yml
   loop:
     - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"


### PR DESCRIPTION
I did't touch requests because when idle our workers consume even less than this.