### PR TITLE
Set cpu limit to 2

### DIFF
--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -206,7 +206,7 @@
     worker_requests_memory: "320Mi"
     worker_requests_cpu: "80m"
     worker_limits_memory: "640Mi"
-    worker_limits_cpu: "4"
+    worker_limits_cpu: "2"
   ansible.builtin.include_tasks: k8s.yml
   loop:
     - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"


### PR DESCRIPTION
We can't assign more than 2cpu to a single pod.