### PR TITLE
Increase cpu limits for postgres

### DIFF
--- a/openshift/dashboard.yml.j2
+++ b/openshift/dashboard.yml.j2
@@ -48,6 +48,7 @@ spec:
               cpu: "5m"
             limits:
               memory: "256Mi"
+              cpu: "50m"
       volumes:
         - name: packit-secrets
           secret:

--- a/openshift/flower.yml.j2
+++ b/openshift/flower.yml.j2
@@ -40,6 +40,7 @@ spec:
               cpu: "5m"
             limits:
               memory: "128Mi"
+              cpu: "50m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/nginx.yml.j2
+++ b/openshift/nginx.yml.j2
@@ -59,6 +59,7 @@ spec:
             cpu: "5m"
           limits:
             memory: "32Mi"
+            cpu: "10m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/packit-service-beat.yml.j2
+++ b/openshift/packit-service-beat.yml.j2
@@ -79,6 +79,7 @@ spec:
               ephemeral-storage: "80Ki"
             limits:
               memory: "256Mi"
+              cpu: "50m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/packit-service-fedmsg.yml.j2
+++ b/openshift/packit-service-fedmsg.yml.j2
@@ -55,6 +55,7 @@ spec:
               cpu: "5m"
             limits:
               memory: "128Mi"
+              cpu: "50m"
           livenessProbe:
             exec:
               command:

--- a/openshift/packit-service.yml.j2
+++ b/openshift/packit-service.yml.j2
@@ -104,6 +104,7 @@ spec:
               # you have to temporarily increase (in webUI/console) the limit
               # and once the alembic upgrade passes, revert.
               memory: "{{ '4Gi' if project == 'packit--prod' else '512Mi' }}"
+              cpu: "200m"
           # In TLS world, hostname needs to match whatever is set in the cert
           # in our cause, k8s is doing here something like curl https://172.15.2.4:8443/api/healthz/
           # which will fail TLS validation.
@@ -142,7 +143,7 @@ spec:
               readOnly: true
           resources:
             requests: {memory: "128Mi", cpu: "10m"}
-            limits: {memory: "128Mi"}
+            limits: {memory: "128Mi", cpu: "100m"}
 {% endif %}
 ---
 apiVersion: v1

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -166,6 +166,7 @@ spec:
               cpu: {{ worker_requests_cpu }}
             limits:
               memory: {{ worker_limits_memory }}
+              cpu: {{ worker_limits_cpu }}
           livenessProbe:
             exec:
               command:
@@ -196,7 +197,7 @@ spec:
               readOnly: true
           resources:
             requests: {memory: "128Mi", cpu: "10m"}
-            limits: {memory: "128Mi"}
+            limits: {memory: "128Mi", cpu: "100m"}
 {% endif %}
 ---
 kind: ImageStream

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -94,7 +94,7 @@ spec:
             - name: DEPLOYMENT
               value: {{ deployment }}
             - name: DISTGIT_URL
-              value: {{ distgit_url }}
+              value: "{{ distgit_url }}"
             - name: DISTGIT_NAMESPACE
               value: {{ distgit_namespace }}
 {% if sourcegit_namespace %}

--- a/openshift/packit-worker.yml.j2
+++ b/openshift/packit-worker.yml.j2
@@ -24,8 +24,8 @@ spec:
       component: {{ component }}
   serviceName: "{{ component }}"
   replicas: {{ worker_replicas }}
-  volumeClaimTemplates:
 {% if with_repository_cache and 'long-running' in queues %}
+  volumeClaimTemplates:
     - metadata:
         name: packit-worker-repository-cache
 {% if managed_platform %}

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -71,6 +71,7 @@ spec:
 # based on this limit, so keep the limit reasonably high.
               memory: "{{ '4Gi' if project == 'packit--prod' else '512Mi' }}"
 # Not utilized most of the time, but useful during migrations and for some queries
+              cpu: "1"
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data

--- a/openshift/postgres.yml.j2
+++ b/openshift/postgres.yml.j2
@@ -71,7 +71,7 @@ spec:
 # based on this limit, so keep the limit reasonably high.
               memory: "{{ '4Gi' if project == 'packit--prod' else '512Mi' }}"
 # Not utilized most of the time, but useful during migrations and for some queries
-              cpu: "1"
+              cpu: "2"
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/pgsql/data

--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -42,6 +42,7 @@ spec:
               cpu: "5m"
             limits:
               memory: "32Mi"
+              cpu: "10m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/pushgateway.yml.j2
+++ b/openshift/pushgateway.yml.j2
@@ -42,7 +42,7 @@ spec:
               cpu: "5m"
             limits:
               memory: "32Mi"
-              cpu: "10m"
+              cpu: "50m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/redict.yml.j2
+++ b/openshift/redict.yml.j2
@@ -43,6 +43,7 @@ spec:
               cpu: "10m"
             limits:
               memory: "256Mi"
+              cpu: "10m"
       volumes:
         - name: redict-pv
           persistentVolumeClaim:

--- a/openshift/redis-commander.yml.j2
+++ b/openshift/redis-commander.yml.j2
@@ -51,6 +51,7 @@ spec:
               cpu: "10m"
             limits:
               memory: "32Mi"
+              cpu: "10m"
   replicas: 1
   strategy:
     type: Recreate

--- a/openshift/redis.yml.j2
+++ b/openshift/redis.yml.j2
@@ -39,6 +39,7 @@ spec:
               cpu: "10m"
             limits:
               memory: "64Mi"
+              cpu: "10m"
       volumes:
         - name: redis-pv
           persistentVolumeClaim:

--- a/openshift/valkey.yml.j2
+++ b/openshift/valkey.yml.j2
@@ -43,7 +43,7 @@ spec:
               cpu: "10m"
             limits:
               memory: "256Mi"
-              cpu: "10m"
+              cpu: "50m"
       volumes:
         - name: valkey-pv
           persistentVolumeClaim:

--- a/openshift/valkey.yml.j2
+++ b/openshift/valkey.yml.j2
@@ -43,6 +43,7 @@ spec:
               cpu: "10m"
             limits:
               memory: "256Mi"
+              cpu: "10m"
       volumes:
         - name: valkey-pv
           persistentVolumeClaim:

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -63,6 +63,7 @@
           cpu: "5m"
         limits:
           memory: "128Mi"
+          cpu: "50m"
     appcode: PCKT-002
     servicephase: lab
     costcenter: "700"

--- a/roles/deploy/defaults/main.yml
+++ b/roles/deploy/defaults/main.yml
@@ -56,6 +56,7 @@ tokman:
       cpu: "5m"
     limits:
       memory: "128Mi"
+      cpu: "50m"
 appcode: PCKT-002
 servicephase: lab
 costcenter: "700"

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -188,6 +188,7 @@
     worker_requests_memory: "384Mi"
     worker_requests_cpu: "100m"
     worker_limits_memory: "1024Mi"
+    worker_limits_cpu: "400m"
   ansible.builtin.include_tasks: k8s.yml
   loop:
     - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"
@@ -205,6 +206,7 @@
     worker_requests_memory: "320Mi"
     worker_requests_cpu: "80m"
     worker_limits_memory: "640Mi"
+    worker_limits_cpu: "2"
   ansible.builtin.include_tasks: k8s.yml
   loop:
     - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"
@@ -236,6 +238,7 @@
     worker_requests_memory: "768Mi"
     worker_requests_cpu: "100m"
     worker_limits_memory: "2048Mi"
+    worker_limits_cpu: "600m"
   ansible.builtin.include_tasks: k8s.yml
   loop:
     - "{{ lookup('template', '{{ project_dir }}/openshift/packit-worker.yml.j2') }}"

--- a/tasks/check-up-to-date.yml
+++ b/tasks/check-up-to-date.yml
@@ -31,7 +31,8 @@
         # Remove the keys expected to be different and lines specific to the diff-format.
         cmd: >-
           diff vars/{{ service }}/{{ deployment }}.yml vars/{{ service }}/{{ deployment }}_template.yml |
-          sed '/api_key/d;/[0-9]\+c[0-9]\+/d;/---/d'
+          sed '/api_key/d;/[0-9]\+c[0-9]\+/d;/---/d' |
+          sed '/host/d;/[0-9]\+c[0-9]\+/d;/---/d'
       register: vars_diff
       changed_when: vars_diff.rc != 0
       failed_when: vars_diff.rc != 0

--- a/vars/packit/dev_template.yml
+++ b/vars/packit/dev_template.yml
@@ -24,7 +24,7 @@ check_up_to_date: false
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
 
-# with_tokman: true
+with_tokman: true
 
 # if you want to deploy fedmsg, please make sure to
 # edit the queue name in secrets/*/fedora.toml

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -99,3 +99,4 @@ tokman:
       cpu: "20m"
     limits:
       memory: "160Mi"
+      cpu: "50m"

--- a/vars/packit/prod_template.yml
+++ b/vars/packit/prod_template.yml
@@ -26,7 +26,7 @@ api_key: ""
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
 
-# with_tokman: false
+with_tokman: false
 
 # if you want to deploy fedmsg, please make sure to
 # edit the queue name in secrets/*/fedora.toml

--- a/vars/packit/stg_template.yml
+++ b/vars/packit/stg_template.yml
@@ -24,7 +24,7 @@ api_key: ""
 # Check that the current vars file us up to date with the template
 # check_vars_template_diff: true
 
-# with_tokman: false
+with_tokman: false
 
 # if you want to deploy fedmsg, please make sure to
 # edit the queue name in secrets/*/fedora.toml


### PR DESCRIPTION
If we don't set cpu limits they are being set by default (500m) but this value is too low for some of our pods.
Keep cpu limits.
Increase postgres cpu limit.
