### PR TITLE
Increase short running worker memory

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,7 @@
 # https://ansible-lint.readthedocs.io/en/latest/configuring.html
 
+profile: basic
+
 skip_list:
   - yaml  # clashes with prettier
 
@@ -14,7 +16,6 @@ mock_modules:
   # Ansible 2.9.27 in F35 still contains the k8s module so we can ignore the error until F36,
   # where we can switch to kubernetes.core.k8s as ansible-5.x in F36 contains it.
   - k8s
-  - kubernetes.core.k8s
   # Ignore until F36, where these are in community.crypto collection (part of ansible-5.x rpm).
   - openssh_keypair
   - openssl_certificate

--- a/playbooks/test_deploy.yml
+++ b/playbooks/test_deploy.yml
@@ -15,7 +15,7 @@
 
   post_tasks:
     - name: Delete test project namespace if already exist
-      kubernetes.core.k8s:
+      k8s:
         name: "{{ test_project_name }}"
         api_version: v1
         kind: Namespace

--- a/playbooks/test_deploy_setup.yml
+++ b/playbooks/test_deploy_setup.yml
@@ -42,14 +42,14 @@
       changed_when: false
 
     - name: Delete test project namespace if already exist
-      kubernetes.core.k8s:
+      k8s:
         name: "{{ test_project_name }}"
         api_version: v1
         kind: Namespace
         state: absent
 
     - name: Create test project namespace
-      kubernetes.core.k8s:
+      k8s:
         name: "{{ test_project_name }}"
         api_version: v1
         kind: Namespace

--- a/roles/deploy/tasks/main.yml
+++ b/roles/deploy/tasks/main.yml
@@ -203,9 +203,9 @@
     worker_replicas: "{{ workers_short_running }}"
     # Short-running tasks are just interactions with different services.
     # They should not require a lot of memory/cpu.
-    worker_requests_memory: "320Mi"
+    worker_requests_memory: "768Mi"
     worker_requests_cpu: "80m"
-    worker_limits_memory: "640Mi"
+    worker_limits_memory: "2048Mi"
     worker_limits_cpu: "2"
   ansible.builtin.include_tasks: k8s.yml
   loop:


### PR DESCRIPTION
After the last memory increase, it seems the workers are using more cpu and executing much more tasks. So memory seems to be a real bottleneck.

![Screenshot From 2025-02-07 10-32-56](https://github.com/user-attachments/assets/85e9aa6c-fad6-496c-8692-473696f10ba1)

![Screenshot From 2025-02-07 11-23-01](https://github.com/user-attachments/assets/5d84bab3-21c9-42ff-aca8-a266ed163478)

