### PR TITLE
Add fedora-ci for packages maintained by lecris

### DIFF
--- a/secrets/packit/stg/packit-service.yaml.j2
+++ b/secrets/packit/stg/packit-service.yaml.j2
@@ -113,6 +113,10 @@ default_parse_time_macros:
     fedora: 0
 
 enabled_projects_for_fedora_ci:
+  - https://src.fedoraproject.org/rpms/dbcsr
   - https://src.fedoraproject.org/rpms/packit
   - https://src.fedoraproject.org/rpms/python-ogr
+  - https://src.fedoraproject.org/rpms/python-scikit-build
+  - https://src.fedoraproject.org/rpms/python-scikit-build-core
   - https://src.fedoraproject.org/rpms/python-specfile
+  - https://src.fedoraproject.org/rpms/spglib


### PR DESCRIPTION
Here are a few packages that I maintain with various levels of permissions `commit`, `collaborator`, `admin`, `maintainer`. I guess the way to test it will be to open a bump PR and see if the `scratch-build` and `testing-farm` workflow work?
