### PR TITLE
Lower the timeout in redis-like config

### DIFF
--- a/openshift/configmap-redis_like_config.yml
+++ b/openshift/configmap-redis_like_config.yml
@@ -5,4 +5,4 @@ metadata:
   name: redis-like-config
 data:
   redis.conf: |
-    timeout 1800
+    timeout 600


### PR DESCRIPTION
This is a timeout after which idle connections are closed. I would try to lower it to 10 mins instead of 30 and see if it helps with downtime for the issue of idle workers (packit/packit-service#2697).


