### PR TITLE
Allow github.com/fdo-rs/fido-device-onboard-rs to use internal TF

### DIFF
--- a/secrets/packit/prod/packit-service.yaml.j2
+++ b/secrets/packit/prod/packit-service.yaml.j2
@@ -44,6 +44,7 @@ enabled_projects_for_internal_tf:
   - github.com/rhel-lightspeed/command-line-assistant
   - github.com/InfrastructureServices/dnsconfd
   - github.com/rhkdump/kdump-utils
+  - github.com/fdo-rs/fido-device-onboard-rs
 
 command_handler: sandcastle
 command_handler_work_dir: /tmp/sandcastle

--- a/secrets/packit/stg/packit-service.yaml.j2
+++ b/secrets/packit/stg/packit-service.yaml.j2
@@ -47,7 +47,7 @@ enabled_projects_for_internal_tf:
   - github.com/rhel-lightspeed/command-line-assistant
   - github.com/InfrastructureServices/dnsconfd
   - github.com/rhkdump/kdump-utils
-
+  - github.com/fdo-rs/fido-device-onboard-rs
 
 command_handler: sandcastle
 command_handler_work_dir: /tmp/sandcastle


### PR DESCRIPTION
We need to enable tests in Image Mode for `fido-device-onboard-rs` upstream project.
In order to do so, we need to be able to use RHEL-10 as target in Packit configuration of the repository.